### PR TITLE
Add reshadow/prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ Rules:
 
 -   [as-attribute](src/eslint/rules/as-attribute/index.js)
 
+### Prettier
+
+Use `reshadow/prettier` if you want to improve your Developer Experience with [prettier](https://github.com/prettier/prettier).
+
 # Special Thanks
 
 -   Pavel Masalsky [@pavelrevers](https://github.com/pavelrevers)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ const Button = ({
         border: 2px solid ${bgcolor};
         background-color: ${rgba(bgcolor, 0.7)};
         color: ${readableColor(bgcolor)};
-        transition: background-color .5s;
+        transition: background-color 0.5s;
 
         &:hover {
             background-color: ${rgba(bgcolor, 0.9)};
@@ -81,19 +81,19 @@ const Button = ({
      * not the DOM attribute
      **/
     button[disabled] {
-        opacity: .5;
+        opacity: 0.5;
         pointer-events: none;
     }
 
     /**
      * Match on the 'use:size' prop
      */
-    button[use|size="s"] {
+    button[use|size='s'] {
         font-size: 12px;
     }
 
     /* The 'use' namespace can be omitted */
-    button[|size="m"] {
+    button[|size='m'] {
         font-size: 14px;
     }
 `(
@@ -138,11 +138,8 @@ import styled from 'reshadow';
 
 import styles from './styles.css';
 
-export const Button = ({size, children}) => styled(styles)(
-    <button use:size={size}>
-        {children}
-    </button>
-);
+export const Button = ({size, children}) =>
+    styled(styles)(<button use:size={size}>{children}</button>);
 ```
 
 _Button/styles.css_
@@ -169,7 +166,7 @@ const anotherStyles = css`
 `;
 
 export const Button = ({size, children}) => styled(
-    props.another && anotherStyles
+    props.another && anotherStyles,
 )`
     button {
         /* button styles */
@@ -177,11 +174,7 @@ export const Button = ({size, children}) => styled(
     button[|size='m'] {
         /* button styles for the size */
     }
-`(
-    <button use:size={size}>
-        {children}
-    </button>
-);
+`(<button use:size={size}>{children}</button>);
 ```
 
 ## Setup
@@ -198,11 +191,7 @@ export const Button = ({children}) => styled`
     button {
         /* button styles */
     }
-`(
-    <button>
-        {children}
-    </button>
-);
+`(<button>{children}</button>);
 ```
 
 Options (via [babel-plugin-macros config](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/author.md#config-experimental)) are the same as `reshadow` [babel options](#babel-options), but with different defaults:
@@ -271,6 +260,14 @@ Rules:
 ### Prettier
 
 Use `reshadow/prettier` if you want to improve your Developer Experience with [prettier](https://github.com/prettier/prettier).
+
+_prettier.config.js_
+
+```js
+module.exports = {
+    plugins: ['reshadow/prettier'],
+};
+```
 
 # Special Thanks
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.2",
+    "version": "0.0.1-alpha.3",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,4 +3,5 @@ module.exports = {
     singleQuote: true,
     trailingComma: 'all',
     bracketSpacing: false,
+    plugins: [require.resolve('./src/prettier')],
 };

--- a/src/prettier/extract/extract-plugin.js
+++ b/src/prettier/extract/extract-plugin.js
@@ -1,0 +1,35 @@
+const postcssParser = require('prettier/parser-postcss');
+const jsParser = require('prettier/parser-babylon');
+
+const _parsers = {
+    css: postcssParser.parsers.css,
+    babel: jsParser.parsers.babel,
+};
+
+let _plugins = {};
+
+const createParser = (parser, printer) => ({
+    [parser]: {
+        ..._parsers[parser],
+        parse(...args) {
+            const ast = _parsers[parser].parse(...args);
+            const [, , options] = args;
+
+            const plugin = options.plugins.find(
+                x => x.printers && x.printers[printer],
+            );
+            _plugins[parser] = {plugin, printer: plugin.printers[printer]};
+
+            return ast;
+        },
+    },
+});
+
+module.exports = {
+    _parsers,
+    _plugins,
+    parsers: {
+        ...createParser('css', 'postcss'),
+        ...createParser('babel', 'estree'),
+    },
+};

--- a/src/prettier/extract/index.js
+++ b/src/prettier/extract/index.js
@@ -1,0 +1,22 @@
+/**
+ * This is a trick to extract the prettier internal plugins
+ */
+
+const prettier = require('prettier');
+
+const {_parsers, _plugins} = require('./extract-plugin');
+
+prettier.format(`;`, {
+    parser: 'css',
+    plugins: [require.resolve('./extract-plugin')],
+});
+
+prettier.format(`;`, {
+    parser: 'babel',
+    plugins: [require.resolve('./extract-plugin')],
+});
+
+module.exports = {
+    _parsers,
+    _plugins,
+};

--- a/src/prettier/index.js
+++ b/src/prettier/index.js
@@ -1,0 +1,136 @@
+const {_parsers, _plugins} = require('./extract');
+
+const extend = (name, cb) => ({
+    ..._plugins[name].printer,
+    ...cb(_plugins[name].printer),
+});
+
+const isStyledTag = tag => tag.type === 'Identifier' && tag.name === 'styled';
+const isStyledCall = tag =>
+    tag.type === 'CallExpression' &&
+    tag.callee.type === 'Identifier' &&
+    tag.callee.name === 'styled';
+
+const isStyledCallee = callee =>
+    callee.type === 'TaggedTemplateExpression' &&
+    (isStyledTag(callee.tag) || isStyledCall(callee.tag));
+
+const isStyledBody = node =>
+    node.type === 'ArrowFunctionExpression' &&
+    node.body.type === 'CallExpression' &&
+    isStyledCallee(node.body.callee);
+
+module.exports = {
+    parsers: {
+        css: {
+            ..._parsers.css,
+            astFormat: 'reshadow-css',
+        },
+        babel: {
+            ..._parsers.babel,
+            astFormat: 'reshadow-babel',
+        },
+    },
+    printers: {
+        'reshadow-css': extend('css', printer => ({
+            print: (...args) => {
+                const [path] = args;
+                const node = path.getNode();
+                const result = printer.print(...args);
+
+                if (node.type === 'selector-tag') {
+                    /**
+                     * keep the original tag name
+                     * @see https://github.com/prettier/prettier/blob/0d0e88cfdf886f8915d25c64391f27f1a931e32e/src/language-css/printer-postcss.js#L344
+                     */
+                    result.parts[1] = node.value;
+                }
+
+                return result;
+            },
+        })),
+        'reshadow-babel': extend('babel', printer => ({
+            print: (...args) => {
+                const [path] = args;
+                const node = path.getNode();
+
+                const result = printer.print(...args);
+
+                if (!isStyledBody(node)) return result;
+
+                if (!result.parts) return result;
+
+                const [functionGroup] = result.parts;
+
+                // Function presented with a pair of an arrow ('=>') and the body
+                let [, bodyGroup] = functionGroup.contents.parts;
+                const body = bodyGroup.contents;
+
+                // remove indent
+                if (body.parts[0].type === 'indent') {
+                    body.parts[0] = body.parts[0].contents;
+                }
+
+                // replace newline with whitespace
+                body.parts[0].parts[0] = ' ';
+
+                /**
+                 * remove unnecessary last comma or newline
+                 * we should remove it only for 2 elements
+                 * for example:
+                 */
+                // const Button = children.map(x => styled`
+                //     div {
+                //         color: green;
+                //     }
+                // `(
+                //     <div {...x} size="m">
+                //         {x}
+                //     </div>,
+                // ),
+                // );
+                if (body.parts.length === 2) {
+                    body.parts.splice(-1);
+                }
+
+                return result;
+            },
+            embed: (...args) => {
+                const [path] = args;
+                const node = path.getNode();
+
+                let parent;
+                let isStyled = false;
+
+                if (node.type === 'TemplateLiteral') {
+                    parent = path.getParentNode();
+
+                    /**
+                     * A hack to force `embed` function act like it is styled component
+                     * @see https://github.com/prettier/prettier/blob/0d0e88cfdf886f8915d25c64391f27f1a931e32e/src/language-js/embed.js#L413
+                     */
+                    if (parent && parent.type === 'TaggedTemplateExpression') {
+                        const {tag} = parent;
+
+                        if (
+                            tag.type === 'Identifier' &&
+                            tag.name === 'styled'
+                        ) {
+                            isStyled = true;
+                            parent.tag.name = 'css';
+                        }
+                    }
+                }
+
+                const result = printer.embed(...args);
+
+                // restore the original name
+                if (isStyled) {
+                    parent.tag.name = 'styled';
+                }
+
+                return result;
+            },
+        })),
+    },
+};

--- a/src/prettier/spec/__snapshots__/index.test.js.snap
+++ b/src/prettier/spec/__snapshots__/index.test.js.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prettier css should keep the capitalized tag 1`] = `
+"Button {
+  color: red;
+}
+
+Button[disabled] {
+  color: red;
+}
+
+Container Button content {
+  font-size: 10px;
+}
+"
+`;
+
+exports[`prettier js should keep process the callback and remove the comma dangle 1`] = `
+"const Button = components.map(x => styled\`
+  div {
+    color: green;
+  }
+\`(
+  <div {...x.props} size=\\"m\\">
+    {x.map(child => styled\`
+      child {
+        opacity: 0.5;
+      }
+    \`(<child>{child}</child>))}
+  </div>
+));
+"
+`;
+
+exports[`prettier js should keep the \`styled\` tag in arrow function and transform the css 1`] = `
+"const Button = ({ children, ...props }) => styled\`
+  Box {
+    margin-top: 10px;
+  }
+\`(
+  <Box {...props} size=\\"s\\">
+    {children}
+  </Box>
+);
+"
+`;
+
+exports[`prettier js should keep the \`styled\` tag with composition 1`] = `
+"const Button = ({ children, ...props }) => styled(style1, style2)\`
+  Box {
+    margin-top: 10px;
+  }
+  button[disabled] {
+    color: gray;
+  }
+\`(
+  <Box {...props} size=\\"s\\">
+    {children}
+  </Box>
+);
+"
+`;
+
+exports[`prettier js should keep the \`styled\` tag with long composition 1`] = `
+"const Button = ({ children, ...props }) => styled(
+  style1,
+  style2,
+  style3,
+  style4,
+  style5,
+  style6
+)\`
+  Box {
+    margin-top: 10px;
+  }
+\`(
+  <Box {...props} size=\\"s\\">
+    {children}
+  </Box>
+);
+"
+`;

--- a/src/prettier/spec/index.test.js
+++ b/src/prettier/spec/index.test.js
@@ -1,0 +1,88 @@
+import prettier from 'prettier';
+import {stripIndent} from 'common-tags';
+
+const transform = options => code =>
+    prettier.format(stripIndent(code), {
+        ...options,
+        plugins: [require.resolve('..')],
+    });
+
+transform.with = options => code => transform(code, options);
+
+describe('prettier', () => {
+    describe('css', () => {
+        it('should keep the capitalized tag', () => {
+            const code = transform({parser: 'css'})`
+                Button {
+                    color: red;
+                }
+
+                Button[disabled] {
+                    color: red;
+                }
+
+                Container Button content {
+                    font-size: 10px;
+                }
+            `;
+
+            expect(code).toMatchSnapshot();
+        });
+    });
+
+    describe('js', () => {
+        it('should keep the `styled` tag in arrow function and transform the css', () => {
+            const code = transform({parser: 'babel'})`
+                const Button = ({children, ...props}) =>
+                styled\`Box {margin-top: 10px;}
+                \`(
+                <Box {...props} size="s">{children}</Box>,
+                );
+            `;
+
+            expect(code).toMatchSnapshot();
+        });
+
+        it('should keep the `styled` tag with composition', () => {
+            const code = transform({parser: 'babel'})`
+                const Button = ({children, ...props}) =>
+                styled(style1, style2)\`Box {margin-top: 10px;} button[disabled] {color: gray;}
+                \`(
+                <Box {...props} size="s">{children}</Box>,
+                );
+            `;
+
+            expect(code).toMatchSnapshot();
+        });
+
+        it('should keep the `styled` tag with long composition', () => {
+            const code = transform({parser: 'babel'})`
+                const Button = ({children, ...props}) =>
+                styled(style1, style2, style3, style4, style5, style6)\`Box {margin-top: 10px;}
+                \`(
+                <Box {...props} size="s">{children}</Box>,
+                );
+            `;
+
+            expect(code).toMatchSnapshot();
+        });
+
+        it('should keep process the callback and remove the comma dangle', () => {
+            const code = transform({parser: 'babel'})`
+            const Button = components.map(x => styled\`
+                div {color: green;}
+            \`(
+                <div {...x.props} size="m">
+                    {x.map(child => styled\`
+                        child {opacity: .5}
+                    \`(
+                        <child>{child}</child>
+                    ))}
+                </div>,
+            ));
+            `;
+
+            expect(code).toMatchSnapshot();
+        });
+    });
+});

--- a/src/runtime/spec/App/index.js
+++ b/src/runtime/spec/App/index.js
@@ -4,22 +4,21 @@ import styled, {use} from 'reshadow';
 import styles from './styles';
 import styles2 from './styles2';
 
-const App = ({disabled, type, color = 'grey'}) =>
-    styled(styles)`
-        button[disabled] {
-            color: ${color};
-        }
-    `(
-        <button
-            className="button"
-            type={type}
-            disabled={disabled}
-            use:theme="normal"
-        >
-            {styled(styles2)(<use:content>content</use:content>)}
+const App = ({disabled, type, color = 'grey'}) => styled(styles)`
+    button[disabled] {
+        color: ${color};
+    }
+`(
+    <button
+        className="button"
+        type={type}
+        disabled={disabled}
+        use:theme="normal"
+    >
+        {styled(styles2)(<use:content>content</use:content>)}
 
-            <use:control>click</use:control>
-        </button>,
-    );
+        <use:control>click</use:control>
+    </button>,
+);
 
 export default App;

--- a/src/webpack/spec/App/index.js
+++ b/src/webpack/spec/App/index.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import styled from 'reshadow';
 
-const App = ({disabled, type, color = 'grey'}) =>
-    styled`
-        button[disabled] {
-            color: ${color};
-        }
-    `(
-        <button type={type} disabled={disabled} use:theme="normal">
-            <control>click</control>
-        </button>,
-    );
+const App = ({disabled, type, color = 'grey'}) => styled`
+    button[disabled] {
+        color: ${color};
+    }
+`(
+    <button type={type} disabled={disabled} use:theme="normal">
+        <control>click</control>
+    </button>,
+);
 
 export default App;


### PR DESCRIPTION
This plugin fixes the following problems with **reshadow** and **prettier**:

- lowercase for `css` tags. for example, prettier transforms tag `Button` to the `button` ([code](https://github.com/prettier/prettier/blob/0d0e88cfdf886f8915d25c64391f27f1a931e32e/src/language-css/printer-postcss.js#L344)), which does not work for the reshadow
- prettier by default does not recognize `css` in the following code:
    ```js
    const Button = props => styled`
        button {color: red}
    `(<button {...props} />)
    ```
  because it does not match on the `styled` template literal tag ([code](https://github.com/prettier/prettier/blob/0d0e88cfdf886f8915d25c64391f27f1a931e32e/src/language-js/embed.js#L448))
- improves prettier behavior with the newline for the `styled` tag in arrow function.
  For example, by default prettier will produce the code like this (considering previous fixes):

    ```js
    const Button = ({ children, ...props }) =>
        styled`
            button {
                color: red;
            }
        `(
            <button size="s" {...props}>
                {children}
            </button>,
        );
    ```

    With `reshadow/prettier` the code will be:

    ```js
    const Button = ({children, ...props}) => styled`
        button {
            color: red;
        }
    `(
        <button size="s" {...props}>
            {children}
        </button>
    )
    ```