### PR TITLE
Fix nested styled elements, use :global for global elements and attrs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.4",
+    "version": "0.0.1-alpha.5",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -281,6 +281,7 @@ module.exports = (babel, pluginOptions = {}) => {
         const elementMap = new Map();
 
         p.traverse({
+            ...visitor,
             JSXElement(elementPath) {
                 const {node} = elementPath;
 
@@ -529,7 +530,7 @@ module.exports = (babel, pluginOptions = {}) => {
         let {node} = p;
         const {quasi, tag} = node;
 
-        if (tag.name !== imports.css) {
+        if (!imports.css || tag.name !== imports.css) {
             return;
         }
 

--- a/src/babel/spec/__snapshots__/index.test.js.snap
+++ b/src/babel/spec/__snapshots__/index.test.js.snap
@@ -491,6 +491,37 @@ const App = ({
 export default App;"
 `;
 
+exports[`babel should transform with css-in-js code with variables in nested elemnts 1`] = `
+"import React from 'react';
+import styled, { set, create, css, map, __css__ } from 'reshadow';
+import styles from './styles';
+const styled_c8 = create([__css__(\`div {
+    padding: 10px;
+}\`, \\"4198542548_c8\\")]);
+const styled_12c = create([__css__(\`button[disabled] {
+    color: var(--12c_0);
+    background-color: var(--12c_1);
+}\`, \\"4198542548_12c\\")]);
+
+const App = ({
+  disabled,
+  type,
+  color,
+  bgcolor
+}) => styled((set([styled_c8]), React.createElement(\\"div\\", {
+  className: styled.styles[\\"__div\\"]
+}, styled((set([styled_12c]), React.createElement(\\"button\\", map(\\"button\\", {
+  type: type,
+  disabled: disabled,
+  $$style: {
+    \\"--12c_0\\": color,
+    \\"--12c_1\\": bgcolor
+  }
+}), \\"content\\"))))));
+
+export default App;"
+`;
+
 exports[`babel should transform with css-in-js code with variables in sibling nodes 1`] = `
 "import React from 'react';
 import styled, { set, create, css, use, map, __css__ } from 'reshadow';

--- a/src/babel/spec/index.test.js
+++ b/src/babel/spec/index.test.js
@@ -188,6 +188,38 @@ describe('babel', () => {
         expect(code).toMatchSnapshot();
     });
 
+    it('should transform with css-in-js code with variables in nested elemnts', async () => {
+        const {code} = await transform`
+            import React from 'react'
+            import styled from 'reshadow'
+
+            import styles from './styles'
+
+            const App = ({disabled, type, color, bgcolor}) => styled\`
+                div {
+                    padding: 10px;
+                }
+            \`(
+                <div>
+                    {styled\`
+                        button[disabled] {
+                            color: \${color};
+                            background-color: \${bgcolor};
+                        }
+                    \`(
+                        <button type={type} disabled={disabled}>
+                            content
+                        </button>
+                    )}
+                </div>
+            )
+
+            export default App
+        `;
+
+        expect(code).toMatchSnapshot();
+    });
+
     it('should keep the links to styles if they cant hoist', async () => {
         const {code} = await transform`
             import React from 'react'

--- a/src/postcss/spec/__snapshots__/index.test.js.snap
+++ b/src/postcss/spec/__snapshots__/index.test.js.snap
@@ -1,8 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`postcss should should keep elements under html namespace 1`] = `
+exports[`postcss should should keep elements under the :global 1`] = `
 ".__content button {
     color: red;
+}
+
+.__button[aria-hidden] {
+    opacity: 0;
+}
+
+.__button[disabled]._use--variant._use--variant_normal {
+    background-color: gray;
 }"
 `;
 

--- a/src/postcss/spec/index.test.js
+++ b/src/postcss/spec/index.test.js
@@ -56,10 +56,18 @@ describe('postcss', () => {
         expect(code).toMatchSnapshot();
     });
 
-    it('should should keep elements under html namespace', () => {
+    it('should should keep elements under the :global', () => {
         const code = transform`
-            content html|button {
+            content :global(button) {
                 color: red;
+            }
+
+            button:global([aria-hidden]) {
+                opacity: 0;
+            }
+
+            button:global([disabled])[|variant=normal] {
+                background-color: gray;
             }
         `;
 

--- a/src/postcss/transform.js
+++ b/src/postcss/transform.js
@@ -1,9 +1,19 @@
 const parser = require('postcss-selector-parser');
 
+const GLOBAL_PSEUDO = ':global';
+
+const isGlobal = node => {
+    const {parent} = node;
+    if (!(parser.isSelector(parent) && parser.isPseudo(parent.parent)))
+        return false;
+
+    return parent.parent.value === GLOBAL_PSEUDO;
+};
+
 module.exports = ({scope}) => {
     const processNamespace = node => {
-        if (node.namespace === 'html') {
-            node.namespace = '';
+        if (isGlobal(node)) {
+            node.parent.parent.replaceWith(node);
             return false;
         }
 


### PR DESCRIPTION
- Fix cssinjs variables for the nested elements

**BREAKING CHANGE**
- use `:global(div)` for global elements instead of `html|div`
- use `:global([disabled])` for the global attribute `disabled` instead of `html|disabled`