### PR TITLE
fix(runtime): fix mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
+
+
+### Features
+
+* **runtime:** support nested elements in mixins and styled functions ([1a2ee38](https://github.com/lttb/reshadow/commit/1a2ee38))
+* **styled:** filter namespaced attributes ([b4779af](https://github.com/lttb/reshadow/commit/b4779af))
+
+
+
+
+
 ## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
+
+
+### Features
+
+* **runtime):** move dynamic units to the runtime ([4134c07](https://github.com/lttb/reshadow/commit/4134c07))
+
+
+
+
+
 ## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.61](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.60...v0.0.1-alpha.61) (2019-06-03)
+
+
+### Bug Fixes
+
+* **svelte:** use @reshadow/core for the runtime ([703668d](https://github.com/lttb/reshadow/commit/703668d))
+
+
+
+
+
 ## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
+
+
+### Bug Fixes
+
+* **runtime:** fix mixins apply order ([1584d66](https://github.com/lttb/reshadow/commit/1584d66))
+
+
+
+
+
 ## [0.0.1-alpha.59](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.58...v0.0.1-alpha.59) (2019-06-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
+
+
+### Bug Fixes
+
+* **runtime:** skip only null and undefined values ([1f85fdf](https://github.com/lttb/reshadow/commit/1f85fdf))
+
+
+### Features
+
+* **runtime:** move dynamic units to the runtime ([965ec27](https://github.com/lttb/reshadow/commit/965ec27))
+
+
+
+
+
 ## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
+
+
+### Bug Fixes
+
+* **core:** fix modifier key check ([c10b2bc](https://github.com/lttb/reshadow/commit/c10b2bc))
+
+
+
+
+
 ## [0.0.1-alpha.61](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.60...v0.0.1-alpha.61) (2019-06-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.59](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.58...v0.0.1-alpha.59) (2019-06-03)
+
+
+### Bug Fixes
+
+* **svelte:** fix variables interpolation ([1ff22b3](https://github.com/lttb/reshadow/commit/1ff22b3))
+
+
+
+
+
 ## [0.0.1-alpha.58](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.57...v0.0.1-alpha.58) (2019-06-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
+
+
+### Features
+
+* **styled:** move units to the dynamic values ([c13cbb7](https://github.com/lttb/reshadow/commit/c13cbb7))
+* **styled:** process only namespaced attributes ([72cc2d5](https://github.com/lttb/reshadow/commit/72cc2d5))
+
+
+
+
+
 ## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.58](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.57...v0.0.1-alpha.58) (2019-06-03)
+
+
+### Bug Fixes
+
+* **svelte:** fix modifiers ([38d2c83](https://github.com/lttb/reshadow/commit/38d2c83))
+
+
+
+
+
 ## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
+
+
+### Features
+
+* **runtime:** use @emotion/stylis, merge mixins into the class to avoid specificity ([e43e634](https://github.com/lttb/reshadow/commit/e43e634))
+
+
+
+
+
 ## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.63](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.62...v0.0.1-alpha.63) (2019-06-04)
+
+
+### Bug Fixes
+
+* **svelte:** fix svelte preprocess ([5e60204](https://github.com/lttb/reshadow/commit/5e60204))
+
+
+
+
+
 ## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
+
+
+### Bug Fixes
+
+* **runtime:** fix mixin detection ([86d2193](https://github.com/lttb/reshadow/commit/86d2193))
+
+
+
+
+
 ## [0.0.1-alpha.51](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.50...v0.0.1-alpha.51) (2019-05-31)
 
 

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.63](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.62...v0.0.1-alpha.63) (2019-06-04)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.59](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.58...v0.0.1-alpha.59) (2019-06-03)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.58](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.57...v0.0.1-alpha.58) (2019-06-03)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.61](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.60...v0.0.1-alpha.61) (2019-06-03)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.59](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.58...v0.0.1-alpha.59) (2019-06-03)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.58](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.57...v0.0.1-alpha.58) (2019-06-03)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.51](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.50...v0.0.1-alpha.51) (2019-05-31)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.61](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.60...v0.0.1-alpha.61) (2019-06-03)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/CHANGELOG.md
+++ b/examples/svelte/hello-world/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
+
+**Note:** Version bump only for package svelte-hello-world
+
+
+
+
+
 ## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
 
 **Note:** Version bump only for package svelte-hello-world

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.55",
+    "version": "0.0.1-alpha.56",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
         "@reshadow/svelte": "^0.0.1-alpha.51",
-        "reshadow": "^0.0.1-alpha.55",
+        "reshadow": "^0.0.1-alpha.56",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.62",
+    "version": "0.0.1-alpha.63",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
-        "@reshadow/svelte": "^0.0.1-alpha.62",
-        "reshadow": "^0.0.1-alpha.62",
+        "@reshadow/svelte": "^0.0.1-alpha.63",
+        "reshadow": "^0.0.1-alpha.63",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.51",
+    "version": "0.0.1-alpha.52",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
         "@reshadow/svelte": "^0.0.1-alpha.51",
-        "reshadow": "^0.0.1-alpha.51",
+        "reshadow": "^0.0.1-alpha.52",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.60",
+    "version": "0.0.1-alpha.61",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
-        "@reshadow/svelte": "^0.0.1-alpha.59",
-        "reshadow": "^0.0.1-alpha.60",
+        "@reshadow/svelte": "^0.0.1-alpha.61",
+        "reshadow": "^0.0.1-alpha.61",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.59",
+    "version": "0.0.1-alpha.60",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
         "@reshadow/svelte": "^0.0.1-alpha.59",
-        "reshadow": "^0.0.1-alpha.59",
+        "reshadow": "^0.0.1-alpha.60",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.52",
+    "version": "0.0.1-alpha.53",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
         "@reshadow/svelte": "^0.0.1-alpha.51",
-        "reshadow": "^0.0.1-alpha.52",
+        "reshadow": "^0.0.1-alpha.53",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.56",
+    "version": "0.0.1-alpha.57",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
-        "@reshadow/svelte": "^0.0.1-alpha.51",
-        "reshadow": "^0.0.1-alpha.56",
+        "@reshadow/svelte": "^0.0.1-alpha.57",
+        "reshadow": "^0.0.1-alpha.57",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.58",
+    "version": "0.0.1-alpha.59",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
-        "@reshadow/svelte": "^0.0.1-alpha.58",
-        "reshadow": "^0.0.1-alpha.58",
+        "@reshadow/svelte": "^0.0.1-alpha.59",
+        "reshadow": "^0.0.1-alpha.59",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.53",
+    "version": "0.0.1-alpha.54",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
         "@reshadow/svelte": "^0.0.1-alpha.51",
-        "reshadow": "^0.0.1-alpha.53",
+        "reshadow": "^0.0.1-alpha.54",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.54",
+    "version": "0.0.1-alpha.55",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
         "@reshadow/svelte": "^0.0.1-alpha.51",
-        "reshadow": "^0.0.1-alpha.54",
+        "reshadow": "^0.0.1-alpha.55",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.57",
+    "version": "0.0.1-alpha.58",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
-        "@reshadow/svelte": "^0.0.1-alpha.57",
-        "reshadow": "^0.0.1-alpha.57",
+        "@reshadow/svelte": "^0.0.1-alpha.58",
+        "reshadow": "^0.0.1-alpha.58",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/examples/svelte/hello-world/package.json
+++ b/examples/svelte/hello-world/package.json
@@ -1,14 +1,14 @@
 {
     "private": true,
     "name": "svelte-hello-world",
-    "version": "0.0.1-alpha.61",
+    "version": "0.0.1-alpha.62",
     "main": "index.html",
     "scripts": {
         "start": "webpack-dev-server --content-base public --hot"
     },
     "dependencies": {
-        "@reshadow/svelte": "^0.0.1-alpha.61",
-        "reshadow": "^0.0.1-alpha.61",
+        "@reshadow/svelte": "^0.0.1-alpha.62",
+        "reshadow": "^0.0.1-alpha.62",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.56",
+    "version": "0.0.1-alpha.57",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.54",
+    "version": "0.0.1-alpha.55",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.59",
+    "version": "0.0.1-alpha.60",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.57",
+    "version": "0.0.1-alpha.58",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.62",
+    "version": "0.0.1-alpha.63",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.61",
+    "version": "0.0.1-alpha.62",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.52",
+    "version": "0.0.1-alpha.53",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.55",
+    "version": "0.0.1-alpha.56",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.60",
+    "version": "0.0.1-alpha.61",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.51",
+    "version": "0.0.1-alpha.52",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.58",
+    "version": "0.0.1-alpha.59",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
         "packages/*",
         "reshadow"
     ],
-    "version": "0.0.1-alpha.53",
+    "version": "0.0.1-alpha.54",
     "npmClient": "yarn",
     "useWorkspaces": true,
     "command": {

--- a/packages/babel/CHANGELOG.md
+++ b/packages/babel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/babel
+
+
+
+
+
 ## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/babel

--- a/packages/babel/CHANGELOG.md
+++ b/packages/babel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.63](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.62...v0.0.1-alpha.63) (2019-06-04)
+
+**Note:** Version bump only for package @reshadow/babel
+
+
+
+
+
 ## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/babel

--- a/packages/babel/CHANGELOG.md
+++ b/packages/babel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/babel
+
+
+
+
+
 ## [0.0.1-alpha.51](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.50...v0.0.1-alpha.51) (2019-05-31)
 
 

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/babel",
-    "version": "0.0.1-alpha.57",
+    "version": "0.0.1-alpha.62",
     "description": "reshadow babel plugin",
     "main": "index.js",
     "repository": {
@@ -24,7 +24,7 @@
         "@babel/plugin-syntax-jsx": "^7.2.0",
         "@babel/template": "^7.2.2",
         "@babel/types": "^7.3.0",
-        "@reshadow/core": "^0.0.1-alpha.57",
+        "@reshadow/core": "^0.0.1-alpha.62",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/utils": "^0.0.1-alpha.30",
         "common-tags": "1.8.0",

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/babel",
-    "version": "0.0.1-alpha.51",
+    "version": "0.0.1-alpha.57",
     "description": "reshadow babel plugin",
     "main": "index.js",
     "repository": {
@@ -24,7 +24,7 @@
         "@babel/plugin-syntax-jsx": "^7.2.0",
         "@babel/template": "^7.2.2",
         "@babel/types": "^7.3.0",
-        "@reshadow/core": "^0.0.1-alpha.49",
+        "@reshadow/core": "^0.0.1-alpha.57",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/utils": "^0.0.1-alpha.30",
         "common-tags": "1.8.0",

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/babel",
-    "version": "0.0.1-alpha.62",
+    "version": "0.0.1-alpha.63",
     "description": "reshadow babel plugin",
     "main": "index.js",
     "repository": {
@@ -24,7 +24,7 @@
         "@babel/plugin-syntax-jsx": "^7.2.0",
         "@babel/template": "^7.2.2",
         "@babel/types": "^7.3.0",
-        "@reshadow/core": "^0.0.1-alpha.62",
+        "@reshadow/core": "^0.0.1-alpha.63",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/utils": "^0.0.1-alpha.30",
         "common-tags": "1.8.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
+
+
+### Features
+
+* **runtime:** support nested elements in mixins and styled functions ([1a2ee38](https://github.com/lttb/reshadow/commit/1a2ee38))
+* **styled:** filter namespaced attributes ([b4779af](https://github.com/lttb/reshadow/commit/b4779af))
+
+
+
+
+
 ## [0.0.1-alpha.49](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.48...v0.0.1-alpha.49) (2019-05-31)
 
 **Note:** Version bump only for package @reshadow/core

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
+
+
+### Bug Fixes
+
+* **core:** fix modifier key check ([c10b2bc](https://github.com/lttb/reshadow/commit/c10b2bc))
+
+
+
+
+
 ## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
 
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.63](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.62...v0.0.1-alpha.63) (2019-06-04)
+
+
+### Bug Fixes
+
+* **svelte:** fix svelte preprocess ([5e60204](https://github.com/lttb/reshadow/commit/5e60204))
+
+
+
+
+
 ## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
 
 

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -295,11 +295,8 @@ function map(element) {
     return nextProps;
 }
 
-Object.defineProperty(exports, '__esModule', {
-    value: true,
-});
-
-Object.assign(exports, {
+module.exports = {
+    __esModule: true,
     default: styled,
     use,
     css,
@@ -329,4 +326,4 @@ Object.assign(exports, {
     USE_PREFIX,
     KEYS,
     RESHADOW_ID,
-});
+};

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -207,6 +207,7 @@ function map(element) {
     let nextProps = {};
     let cn = appendElement(styled[KEYS.__styles__], element);
     let vars = null;
+    let uses = styled[KEYS.__styles__][KEYS.__use__] || {};
 
     const len = arguments.length;
 
@@ -234,9 +235,22 @@ function map(element) {
 
             const value = currProps[key];
 
-            nextProps[key] = value;
-
             cn = appendModifier(styled[KEYS.__styles__], key, value, cn);
+
+            if (key in uses) {
+                cn = appendModifier(
+                    styled[KEYS.__styles__],
+                    USE_PREFIX + key,
+                    value,
+                    cn,
+                );
+
+                if (uses[key][value]) {
+                    continue;
+                }
+            }
+
+            nextProps[key] = value;
         }
     }
 

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -248,11 +248,25 @@ function map(element) {
 
             cn = appendModifier(currStyles, key, value, cn);
 
-            if (key + '_' + true in uses || key + '_' + value) {
-                cn = appendModifier(currStyles, USE_PREFIX + key, value, cn);
+            const valueType = typeof value;
 
-                if (uses[key + '_' + value]) {
-                    continue;
+            if (
+                valueType === 'string' ||
+                valueType === 'boolean' ||
+                valueType === 'number'
+            ) {
+                const useKey = key + '_' + value;
+                if (key + '_' + true in uses || useKey in uses) {
+                    cn = appendModifier(
+                        currStyles,
+                        USE_PREFIX + key,
+                        value,
+                        cn,
+                    );
+
+                    if (uses[useKey]) {
+                        continue;
+                    }
                 }
             }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/core",
-    "version": "0.0.1-alpha.49",
+    "version": "0.0.1-alpha.57",
     "description": "reshadow core runtime",
     "main": "index.js",
     "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/core",
-    "version": "0.0.1-alpha.57",
+    "version": "0.0.1-alpha.62",
     "description": "reshadow core runtime",
     "main": "index.js",
     "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/core",
-    "version": "0.0.1-alpha.62",
+    "version": "0.0.1-alpha.63",
     "description": "reshadow core runtime",
     "main": "index.js",
     "repository": {

--- a/packages/macro/CHANGELOG.md
+++ b/packages/macro/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/macro
+
+
+
+
+
 ## [0.0.1-alpha.51](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.50...v0.0.1-alpha.51) (2019-05-31)
 
 **Note:** Version bump only for package @reshadow/macro

--- a/packages/macro/CHANGELOG.md
+++ b/packages/macro/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.63](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.62...v0.0.1-alpha.63) (2019-06-04)
+
+**Note:** Version bump only for package @reshadow/macro
+
+
+
+
+
 ## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/macro

--- a/packages/macro/CHANGELOG.md
+++ b/packages/macro/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/macro
+
+
+
+
+
 ## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/macro

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/macro",
-    "version": "0.0.1-alpha.57",
+    "version": "0.0.1-alpha.62",
     "description": "reshadow babel-plugin-macros plugin",
     "main": "index.js",
     "repository": {
@@ -20,8 +20,8 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/babel": "^0.0.1-alpha.57",
-        "@reshadow/core": "^0.0.1-alpha.57",
+        "@reshadow/babel": "^0.0.1-alpha.62",
+        "@reshadow/core": "^0.0.1-alpha.62",
         "babel-plugin-macros": "2.5.1"
     }
 }

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/macro",
-    "version": "0.0.1-alpha.62",
+    "version": "0.0.1-alpha.63",
     "description": "reshadow babel-plugin-macros plugin",
     "main": "index.js",
     "repository": {
@@ -20,8 +20,8 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/babel": "^0.0.1-alpha.62",
-        "@reshadow/core": "^0.0.1-alpha.62",
+        "@reshadow/babel": "^0.0.1-alpha.63",
+        "@reshadow/core": "^0.0.1-alpha.63",
         "babel-plugin-macros": "2.5.1"
     }
 }

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/macro",
-    "version": "0.0.1-alpha.51",
+    "version": "0.0.1-alpha.57",
     "description": "reshadow babel-plugin-macros plugin",
     "main": "index.js",
     "repository": {
@@ -20,8 +20,8 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/babel": "^0.0.1-alpha.51",
-        "@reshadow/core": "^0.0.1-alpha.49",
+        "@reshadow/babel": "^0.0.1-alpha.57",
+        "@reshadow/core": "^0.0.1-alpha.57",
         "babel-plugin-macros": "2.5.1"
     }
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
+
+**Note:** Version bump only for package @reshadow/react
+
+
+
+
+
 ## [0.0.1-alpha.49](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.48...v0.0.1-alpha.49) (2019-05-31)
 
 **Note:** Version bump only for package @reshadow/react

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/react
+
+
+
+
+
 ## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
 
 **Note:** Version bump only for package @reshadow/react

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
+
+**Note:** Version bump only for package @reshadow/react
+
+
+
+
+
 ## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
 
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
+
+**Note:** Version bump only for package @reshadow/react
+
+
+
+
+
 ## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
 
 **Note:** Version bump only for package @reshadow/react

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
+
+
+### Features
+
+* **runtime:** use @emotion/stylis, merge mixins into the class to avoid specificity ([e43e634](https://github.com/lttb/reshadow/commit/e43e634))
+
+
+
+
+
 ## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
 
 **Note:** Version bump only for package @reshadow/react

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/react
+
+
+
+
+
 ## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
 
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.63](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.62...v0.0.1-alpha.63) (2019-06-04)
+
+**Note:** Version bump only for package @reshadow/react
+
+
+
+
+
 ## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/react

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
+
+**Note:** Version bump only for package @reshadow/react
+
+
+
+
+
 ## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
 
 **Note:** Version bump only for package @reshadow/react

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
+
+
+### Bug Fixes
+
+* **runtime:** fix mixins apply order ([1584d66](https://github.com/lttb/reshadow/commit/1584d66))
+
+
+
+
+
 ## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/react

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/react",
-    "version": "0.0.1-alpha.49",
+    "version": "0.0.1-alpha.52",
     "description": "reshadow react",
     "main": "index.js",
     "repository": {
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/runtime": "^0.0.1-alpha.49",
+        "@reshadow/runtime": "^0.0.1-alpha.52",
         "@reshadow/utils": "^0.0.1-alpha.30"
     },
     "optionalDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/react",
-    "version": "0.0.1-alpha.57",
+    "version": "0.0.1-alpha.60",
     "description": "reshadow react",
     "main": "index.js",
     "repository": {
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.57",
-        "@reshadow/runtime": "^0.0.1-alpha.57",
+        "@reshadow/runtime": "^0.0.1-alpha.60",
         "@reshadow/utils": "^0.0.1-alpha.30"
     },
     "optionalDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/react",
-    "version": "0.0.1-alpha.54",
+    "version": "0.0.1-alpha.55",
     "description": "reshadow react",
     "main": "index.js",
     "repository": {
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/runtime": "^0.0.1-alpha.54",
+        "@reshadow/runtime": "^0.0.1-alpha.55",
         "@reshadow/utils": "^0.0.1-alpha.30"
     },
     "optionalDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/react",
-    "version": "0.0.1-alpha.53",
+    "version": "0.0.1-alpha.54",
     "description": "reshadow react",
     "main": "index.js",
     "repository": {
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/runtime": "^0.0.1-alpha.53",
+        "@reshadow/runtime": "^0.0.1-alpha.54",
         "@reshadow/utils": "^0.0.1-alpha.30"
     },
     "optionalDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/react",
-    "version": "0.0.1-alpha.62",
+    "version": "0.0.1-alpha.63",
     "description": "reshadow react",
     "main": "index.js",
     "repository": {
@@ -20,8 +20,8 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/core": "^0.0.1-alpha.62",
-        "@reshadow/runtime": "^0.0.1-alpha.62",
+        "@reshadow/core": "^0.0.1-alpha.63",
+        "@reshadow/runtime": "^0.0.1-alpha.63",
         "@reshadow/utils": "^0.0.1-alpha.30"
     },
     "optionalDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/react",
-    "version": "0.0.1-alpha.56",
+    "version": "0.0.1-alpha.57",
     "description": "reshadow react",
     "main": "index.js",
     "repository": {
@@ -20,8 +20,8 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/runtime": "^0.0.1-alpha.56",
+        "@reshadow/core": "^0.0.1-alpha.57",
+        "@reshadow/runtime": "^0.0.1-alpha.57",
         "@reshadow/utils": "^0.0.1-alpha.30"
     },
     "optionalDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/react",
-    "version": "0.0.1-alpha.55",
+    "version": "0.0.1-alpha.56",
     "description": "reshadow react",
     "main": "index.js",
     "repository": {
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/runtime": "^0.0.1-alpha.55",
+        "@reshadow/runtime": "^0.0.1-alpha.56",
         "@reshadow/utils": "^0.0.1-alpha.30"
     },
     "optionalDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/react",
-    "version": "0.0.1-alpha.60",
+    "version": "0.0.1-alpha.62",
     "description": "reshadow react",
     "main": "index.js",
     "repository": {
@@ -20,8 +20,8 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/core": "^0.0.1-alpha.57",
-        "@reshadow/runtime": "^0.0.1-alpha.60",
+        "@reshadow/core": "^0.0.1-alpha.62",
+        "@reshadow/runtime": "^0.0.1-alpha.62",
         "@reshadow/utils": "^0.0.1-alpha.30"
     },
     "optionalDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/react",
-    "version": "0.0.1-alpha.52",
+    "version": "0.0.1-alpha.53",
     "description": "reshadow react",
     "main": "index.js",
     "repository": {
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/runtime": "^0.0.1-alpha.52",
+        "@reshadow/runtime": "^0.0.1-alpha.53",
         "@reshadow/utils": "^0.0.1-alpha.30"
     },
     "optionalDependencies": {

--- a/packages/react/spec/__snapshots__/index.test.js.snap
+++ b/packages/react/spec/__snapshots__/index.test.js.snap
@@ -9,7 +9,7 @@ exports[`react should apply composed mixins 1`] = `
 </button>
 `;
 
-exports[`react should apply composed mixins 2`] = `".__button_lm3xvp{margin:10px;}.__button_lm3xvp{color:var(--1owzm37_1);}.__button_lm3xvp{padding:5px 10px;}"`;
+exports[`react should apply composed mixins 2`] = `".__button_lm3xvp{padding:5px 10px;color:var(--1owzm37_1);margin:10px;}"`;
 
 exports[`react should apply conditional mixins 1`] = `
 <button
@@ -20,7 +20,7 @@ exports[`react should apply conditional mixins 1`] = `
 </button>
 `;
 
-exports[`react should apply conditional mixins 2`] = `".__button_nzpf5v{margin:10px;}.__button_nzpf5v{color:white;background:var(--14y9117_1);}"`;
+exports[`react should apply conditional mixins 2`] = `".__button_nzpf5v{color:white;background:var(--14y9117_1);margin:10px;}"`;
 
 exports[`react should apply conditional mixins 3`] = `
 <button
@@ -31,7 +31,7 @@ exports[`react should apply conditional mixins 3`] = `
 </button>
 `;
 
-exports[`react should apply conditional mixins 4`] = `".__button_nzpf5v{margin:10px;}.__button_nzpf5v{color:white;background:var(--14y9117_1);}.__button_1pj7rgr{margin:10px;}.__button_1pj7rgr{color:var(--134zod7_1);background:white;}"`;
+exports[`react should apply conditional mixins 4`] = `".__button_nzpf5v{color:white;background:var(--14y9117_1);margin:10px;}.__button_1pj7rgr{color:var(--134zod7_1);background:white;margin:10px;}"`;
 
 exports[`react should apply dynamic mixins 1`] = `
 <button
@@ -42,7 +42,7 @@ exports[`react should apply dynamic mixins 1`] = `
 </button>
 `;
 
-exports[`react should apply dynamic mixins 2`] = `".__button_1hzemul{margin:10px;}.__button_1hzemul{color:var(--xqnn5g_1);border:none;}"`;
+exports[`react should apply dynamic mixins 2`] = `".__button_1hzemul{color:var(--xqnn5g_1);border:none;margin:10px;}"`;
 
 exports[`react should apply dynamic mixins 3`] = `
 <button
@@ -53,7 +53,7 @@ exports[`react should apply dynamic mixins 3`] = `
 </button>
 `;
 
-exports[`react should apply dynamic mixins 4`] = `".__button_1hzemul{margin:10px;}.__button_1hzemul{color:var(--xqnn5g_1);border:none;}"`;
+exports[`react should apply dynamic mixins 4`] = `".__button_1hzemul{color:var(--xqnn5g_1);border:none;margin:10px;}"`;
 
 exports[`react should apply dynamic styles 1`] = `
 <button
@@ -127,7 +127,7 @@ exports[`react should apply mixins 1`] = `
 </button>
 `;
 
-exports[`react should apply mixins 2`] = `".__button_13d2oc0{margin:10px;}.__button_13d2oc0{color:red;border:none;}"`;
+exports[`react should apply mixins 2`] = `".__button_13d2oc0{color:red;border:none;margin:10px;}"`;
 
 exports[`react should apply mixins with pseudo 1`] = `
 <button
@@ -137,7 +137,7 @@ exports[`react should apply mixins with pseudo 1`] = `
 </button>
 `;
 
-exports[`react should apply mixins with pseudo 2`] = `".__button_1tuwmo{margin:10px;}.__button_1tuwmo{color:red;border:none;}.__button_1tuwmo:focus{color:green;}"`;
+exports[`react should apply mixins with pseudo 2`] = `".__button_1tuwmo:focus{color:green;}.__button_1tuwmo{color:red;border:none;margin:10px;}"`;
 
 exports[`react should apply object mixins 1`] = `
 <button
@@ -147,7 +147,7 @@ exports[`react should apply object mixins 1`] = `
 </button>
 `;
 
-exports[`react should apply object mixins 2`] = `".__button_qjpl95{margin:10px;}.__button_qjpl95{padding:5px 10px;}"`;
+exports[`react should apply object mixins 2`] = `".__button_qjpl95{padding:5px 10px;margin:10px;}"`;
 
 exports[`react should apply styles 1`] = `
 <button

--- a/packages/react/spec/__snapshots__/index.test.js.snap
+++ b/packages/react/spec/__snapshots__/index.test.js.snap
@@ -9,7 +9,7 @@ exports[`react should apply composed mixins 1`] = `
 </button>
 `;
 
-exports[`react should apply composed mixins 2`] = `".__button_lm3xvp{padding:5px 10px;color:var(--1owzm37_1);margin:10px;}"`;
+exports[`react should apply composed mixins 2`] = `".__button_lm3xvp{color:var(--1owzm37_1);padding:5px 10px;margin:10px;}"`;
 
 exports[`react should apply conditional mixins 1`] = `
 <button

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
+
+**Note:** Version bump only for package reshadow
+
+
+
+
+
 ## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
 
 **Note:** Version bump only for package reshadow

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
+
+**Note:** Version bump only for package reshadow
+
+
+
+
+
 ## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
 
 **Note:** Version bump only for package reshadow

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
+
+
+### Features
+
+* **runtime:** support nested elements in mixins and styled functions ([1a2ee38](https://github.com/lttb/reshadow/commit/1a2ee38))
+
+
+
+
+
 ## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
 
 **Note:** Version bump only for package reshadow

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.63](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.62...v0.0.1-alpha.63) (2019-06-04)
+
+**Note:** Version bump only for package reshadow
+
+
+
+
+
 ## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
 
 **Note:** Version bump only for package reshadow

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
+
+**Note:** Version bump only for package reshadow
+
+
+
+
+
 ## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
 
 **Note:** Version bump only for package reshadow

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.58](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.57...v0.0.1-alpha.58) (2019-06-03)
+
+**Note:** Version bump only for package reshadow
+
+
+
+
+
 ## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
 
 

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
+
+**Note:** Version bump only for package reshadow
+
+
+
+
+
 ## [0.0.1-alpha.61](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.60...v0.0.1-alpha.61) (2019-06-03)
 
 **Note:** Version bump only for package reshadow

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
+
+**Note:** Version bump only for package reshadow
+
+
+
+
+
 ## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
 
 **Note:** Version bump only for package reshadow

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
+
+**Note:** Version bump only for package reshadow
+
+
+
+
+
 ## [0.0.1-alpha.51](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.50...v0.0.1-alpha.51) (2019-05-31)
 
 **Note:** Version bump only for package reshadow

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.61](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.60...v0.0.1-alpha.61) (2019-06-03)
+
+**Note:** Version bump only for package reshadow
+
+
+
+
+
 ## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
 
 **Note:** Version bump only for package reshadow

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
+
+**Note:** Version bump only for package reshadow
+
+
+
+
+
 ## [0.0.1-alpha.59](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.58...v0.0.1-alpha.59) (2019-06-03)
 
 **Note:** Version bump only for package reshadow

--- a/packages/reshadow/CHANGELOG.md
+++ b/packages/reshadow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.59](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.58...v0.0.1-alpha.59) (2019-06-03)
+
+**Note:** Version bump only for package reshadow
+
+
+
+
+
 ## [0.0.1-alpha.58](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.57...v0.0.1-alpha.58) (2019-06-03)
 
 **Note:** Version bump only for package reshadow

--- a/packages/reshadow/build.sh
+++ b/packages/reshadow/build.sh
@@ -9,6 +9,7 @@ filelist=(
     postcss
     prettier
     react
+    styled
     svelte
     svelte/preprocess
     vue

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.54",
+    "version": "0.0.1-alpha.55",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -26,7 +26,7 @@
         "@reshadow/macro": "^0.0.1-alpha.51",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
-        "@reshadow/react": "^0.0.1-alpha.54",
+        "@reshadow/react": "^0.0.1-alpha.55",
         "@reshadow/svelte": "^0.0.1-alpha.51",
         "@reshadow/vue": "^0.0.1-alpha.49",
         "@reshadow/webpack": "^0.0.1-alpha.49"

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.59",
+    "version": "0.0.1-alpha.60",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -26,7 +26,7 @@
         "@reshadow/macro": "^0.0.1-alpha.57",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
-        "@reshadow/react": "^0.0.1-alpha.57",
+        "@reshadow/react": "^0.0.1-alpha.60",
         "@reshadow/svelte": "^0.0.1-alpha.59",
         "@reshadow/vue": "^0.0.1-alpha.57",
         "@reshadow/webpack": "^0.0.1-alpha.49"

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.58",
+    "version": "0.0.1-alpha.59",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -27,7 +27,7 @@
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
         "@reshadow/react": "^0.0.1-alpha.57",
-        "@reshadow/svelte": "^0.0.1-alpha.58",
+        "@reshadow/svelte": "^0.0.1-alpha.59",
         "@reshadow/vue": "^0.0.1-alpha.57",
         "@reshadow/webpack": "^0.0.1-alpha.49"
     }

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.51",
+    "version": "0.0.1-alpha.52",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -26,7 +26,7 @@
         "@reshadow/macro": "^0.0.1-alpha.51",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
-        "@reshadow/react": "^0.0.1-alpha.49",
+        "@reshadow/react": "^0.0.1-alpha.52",
         "@reshadow/svelte": "^0.0.1-alpha.51",
         "@reshadow/vue": "^0.0.1-alpha.49",
         "@reshadow/webpack": "^0.0.1-alpha.49"

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.53",
+    "version": "0.0.1-alpha.54",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -26,7 +26,7 @@
         "@reshadow/macro": "^0.0.1-alpha.51",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
-        "@reshadow/react": "^0.0.1-alpha.53",
+        "@reshadow/react": "^0.0.1-alpha.54",
         "@reshadow/svelte": "^0.0.1-alpha.51",
         "@reshadow/vue": "^0.0.1-alpha.49",
         "@reshadow/webpack": "^0.0.1-alpha.49"

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.56",
+    "version": "0.0.1-alpha.57",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -20,15 +20,15 @@
         "build": "../../build.sh && ./build.sh"
     },
     "dependencies": {
-        "@reshadow/babel": "^0.0.1-alpha.51",
-        "@reshadow/core": "^0.0.1-alpha.49",
+        "@reshadow/babel": "^0.0.1-alpha.57",
+        "@reshadow/core": "^0.0.1-alpha.57",
         "@reshadow/eslint": "^0.0.1-alpha.30",
-        "@reshadow/macro": "^0.0.1-alpha.51",
+        "@reshadow/macro": "^0.0.1-alpha.57",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
-        "@reshadow/react": "^0.0.1-alpha.56",
-        "@reshadow/svelte": "^0.0.1-alpha.51",
-        "@reshadow/vue": "^0.0.1-alpha.49",
+        "@reshadow/react": "^0.0.1-alpha.57",
+        "@reshadow/svelte": "^0.0.1-alpha.57",
+        "@reshadow/vue": "^0.0.1-alpha.57",
         "@reshadow/webpack": "^0.0.1-alpha.49"
     }
 }

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.55",
+    "version": "0.0.1-alpha.56",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -26,7 +26,7 @@
         "@reshadow/macro": "^0.0.1-alpha.51",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
-        "@reshadow/react": "^0.0.1-alpha.55",
+        "@reshadow/react": "^0.0.1-alpha.56",
         "@reshadow/svelte": "^0.0.1-alpha.51",
         "@reshadow/vue": "^0.0.1-alpha.49",
         "@reshadow/webpack": "^0.0.1-alpha.49"

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.52",
+    "version": "0.0.1-alpha.53",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -26,7 +26,7 @@
         "@reshadow/macro": "^0.0.1-alpha.51",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
-        "@reshadow/react": "^0.0.1-alpha.52",
+        "@reshadow/react": "^0.0.1-alpha.53",
         "@reshadow/svelte": "^0.0.1-alpha.51",
         "@reshadow/vue": "^0.0.1-alpha.49",
         "@reshadow/webpack": "^0.0.1-alpha.49"

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.57",
+    "version": "0.0.1-alpha.58",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -27,7 +27,7 @@
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
         "@reshadow/react": "^0.0.1-alpha.57",
-        "@reshadow/svelte": "^0.0.1-alpha.57",
+        "@reshadow/svelte": "^0.0.1-alpha.58",
         "@reshadow/vue": "^0.0.1-alpha.57",
         "@reshadow/webpack": "^0.0.1-alpha.49"
     }

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.61",
+    "version": "0.0.1-alpha.62",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -20,15 +20,15 @@
         "build": "../../build.sh && ./build.sh"
     },
     "dependencies": {
-        "@reshadow/babel": "^0.0.1-alpha.57",
-        "@reshadow/core": "^0.0.1-alpha.57",
+        "@reshadow/babel": "^0.0.1-alpha.62",
+        "@reshadow/core": "^0.0.1-alpha.62",
         "@reshadow/eslint": "^0.0.1-alpha.30",
-        "@reshadow/macro": "^0.0.1-alpha.57",
+        "@reshadow/macro": "^0.0.1-alpha.62",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
-        "@reshadow/react": "^0.0.1-alpha.60",
-        "@reshadow/svelte": "^0.0.1-alpha.61",
-        "@reshadow/vue": "^0.0.1-alpha.57",
+        "@reshadow/react": "^0.0.1-alpha.62",
+        "@reshadow/svelte": "^0.0.1-alpha.62",
+        "@reshadow/vue": "^0.0.1-alpha.62",
         "@reshadow/webpack": "^0.0.1-alpha.49"
     }
 }

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.60",
+    "version": "0.0.1-alpha.61",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -27,7 +27,7 @@
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
         "@reshadow/react": "^0.0.1-alpha.60",
-        "@reshadow/svelte": "^0.0.1-alpha.59",
+        "@reshadow/svelte": "^0.0.1-alpha.61",
         "@reshadow/vue": "^0.0.1-alpha.57",
         "@reshadow/webpack": "^0.0.1-alpha.49"
     }

--- a/packages/reshadow/package.json
+++ b/packages/reshadow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reshadow",
-    "version": "0.0.1-alpha.62",
+    "version": "0.0.1-alpha.63",
     "description": "reshadow",
     "main": "index.js",
     "repository": {
@@ -20,15 +20,15 @@
         "build": "../../build.sh && ./build.sh"
     },
     "dependencies": {
-        "@reshadow/babel": "^0.0.1-alpha.62",
-        "@reshadow/core": "^0.0.1-alpha.62",
+        "@reshadow/babel": "^0.0.1-alpha.63",
+        "@reshadow/core": "^0.0.1-alpha.63",
         "@reshadow/eslint": "^0.0.1-alpha.30",
-        "@reshadow/macro": "^0.0.1-alpha.62",
+        "@reshadow/macro": "^0.0.1-alpha.63",
         "@reshadow/postcss": "^0.0.1-alpha.30",
         "@reshadow/prettier": "^0.0.1-alpha.30",
-        "@reshadow/react": "^0.0.1-alpha.62",
-        "@reshadow/svelte": "^0.0.1-alpha.62",
-        "@reshadow/vue": "^0.0.1-alpha.62",
+        "@reshadow/react": "^0.0.1-alpha.63",
+        "@reshadow/svelte": "^0.0.1-alpha.63",
+        "@reshadow/vue": "^0.0.1-alpha.63",
         "@reshadow/webpack": "^0.0.1-alpha.49"
     }
 }

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
+
+
+### Features
+
+* **styled:** process only namespaced attributes ([72cc2d5](https://github.com/lttb/reshadow/commit/72cc2d5))
+
+
+
+
+
 ## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
 
 

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
+
+
+### Features
+
+* **runtime:** support nested elements in mixins and styled functions ([1a2ee38](https://github.com/lttb/reshadow/commit/1a2ee38))
+* **styled:** filter namespaced attributes ([b4779af](https://github.com/lttb/reshadow/commit/b4779af))
+
+
+
+
+
 ## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
 
 

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
+
+
+### Features
+
+* **runtime):** move dynamic units to the runtime ([4134c07](https://github.com/lttb/reshadow/commit/4134c07))
+
+
+
+
+
 ## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
 
 

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.63](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.62...v0.0.1-alpha.63) (2019-06-04)
+
+**Note:** Version bump only for package @reshadow/runtime
+
+
+
+
+
 ## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/runtime

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
+
+
+### Bug Fixes
+
+* **runtime:** skip only null and undefined values ([1f85fdf](https://github.com/lttb/reshadow/commit/1f85fdf))
+
+
+### Features
+
+* **runtime:** move dynamic units to the runtime ([965ec27](https://github.com/lttb/reshadow/commit/965ec27))
+
+
+
+
+
 ## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
 
 

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
+
+
+### Features
+
+* **runtime:** use @emotion/stylis, merge mixins into the class to avoid specificity ([e43e634](https://github.com/lttb/reshadow/commit/e43e634))
+
+
+
+
+
 ## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
 
 

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/runtime
+
+
+
+
+
 ## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
 
 

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
+
+
+### Bug Fixes
+
+* **runtime:** fix mixins apply order ([1584d66](https://github.com/lttb/reshadow/commit/1584d66))
+
+
+
+
+
 ## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
 
 

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
+
+
+### Bug Fixes
+
+* **runtime:** fix mixin detection ([86d2193](https://github.com/lttb/reshadow/commit/86d2193))
+
+
+
+
+
 ## [0.0.1-alpha.49](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.48...v0.0.1-alpha.49) (2019-05-31)
 
 **Note:** Version bump only for package @reshadow/runtime

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -11,6 +11,8 @@ const checkMixin = code => {
     return true;
 };
 
+const unitRe = /^[\s\n\r]*(cm|mm|in|px|pt|pc|em|ex|ch|rem|vw|vh|vmin|vmax|%)[\s\n\r]*[,;)]/;
+
 const createCSS = ({
     parse = defaultParse,
     elements = true,
@@ -21,7 +23,7 @@ const createCSS = ({
     const cache = {};
 
     function css() {
-        const str = arguments[0];
+        const str = [...arguments[0]];
         const hash = stringHash(str.join('')).toString(36);
         let mixinsHash = '';
         let parsed;
@@ -30,7 +32,8 @@ const createCSS = ({
         const mixins = {};
 
         for (let i = 1, len = arguments.length; i < len; i++) {
-            const value = arguments[i];
+            let value = arguments[i];
+
             if (!value) {
                 mixins[i] = '';
             } else if (typeof value === 'object') {
@@ -46,6 +49,15 @@ const createCSS = ({
                 }
             } else {
                 const name = '--' + hash + '_' + i;
+
+                const matchUnit = str[i] && str[i].match(unitRe);
+                if (matchUnit) {
+                    const match = matchUnit[0];
+                    value += matchUnit[1];
+                    str[i] =
+                        match[match.length - 1] + str[i].slice(match.length);
+                }
+
                 vars[name] = value;
             }
         }

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -3,6 +3,14 @@ import stringHash from 'string-hash';
 import defaultParse from './parse';
 import obj2css from './obj2css';
 
+const mixinRe = /^[\r\n\s]*(&|::?[\w-]+|[\w-]+:)/;
+const checkMixin = code => {
+    const match = code.match(mixinRe);
+    if (!match) return false;
+    if (match[1] === ':global') return false;
+    return true;
+};
+
 const createCSS = ({
     parse = defaultParse,
     elements = true,
@@ -60,7 +68,7 @@ const createCSS = ({
             }
 
             let code = String.raw({raw: str}, ...values);
-            let isMixin = /^[\r\n\s]*\w+:/.test(code);
+            let isMixin = checkMixin(code);
 
             parsed = parse(code, cacheKey, {
                 elements,

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -34,7 +34,7 @@ const createCSS = ({
         for (let i = 1, len = arguments.length; i < len; i++) {
             let value = arguments[i];
 
-            if (!value) {
+            if (value === null || value === undefined) {
                 mixins[i] = '';
             } else if (typeof value === 'object') {
                 if (KEYS.__style__ in value) {

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -16,6 +16,7 @@ const createCSS = ({
     elements = true,
     attributes = true,
     classes = true,
+    onlyNamespaced = false,
 } = {}) => {
     const cache = {};
 
@@ -74,6 +75,7 @@ const createCSS = ({
                 elements,
                 attributes,
                 classes,
+                onlyNamespaced,
                 isMixin,
             });
 

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -30,6 +30,8 @@ const createCSS = ({
 
         const vars = {};
         const mixins = {};
+        const mixinTokens = [];
+        const mixinUses = {};
 
         for (let i = 1, len = arguments.length; i < len; i++) {
             let value = arguments[i];
@@ -37,16 +39,16 @@ const createCSS = ({
             if (value === null || value === undefined) {
                 mixins[i] = '';
             } else if (typeof value === 'object') {
-                if (KEYS.__style__ in value) {
-                    Object.assign(vars, value[KEYS.__style__]);
-                    mixinsHash += '_' + value[KEYS.__hash__];
-                    mixins[i] = value[KEYS.__css__];
-                } else {
-                    const result = css([obj2css(value)]);
-                    Object.assign(vars, result[KEYS.__style__]);
-                    mixinsHash += '_' + result[KEYS.__hash__];
-                    mixins[i] = result[KEYS.__css__];
+                if (!(KEYS.__style__ in value)) {
+                    value = css([obj2css(value)]);
                 }
+
+                Object.assign(vars, value[KEYS.__style__]);
+                mixinsHash += '_' + value[KEYS.__hash__];
+                mixins[i] = value[KEYS.__css__];
+
+                mixinTokens.push(value);
+                Object.assign(mixinUses, value[KEYS.__use__]);
             } else {
                 const name = '--' + hash + '_' + i;
 
@@ -94,6 +96,8 @@ const createCSS = ({
             if (!isMixin) {
                 __css__(parsed.css, cacheKey);
             }
+
+            parsed.tokens = create([parsed.tokens].concat(mixinTokens));
 
             parsed.tokens[KEYS.__hash__] = cacheKey;
             parsed.tokens[KEYS.__css__] = parsed.css;

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -47,6 +47,11 @@ const createCSS = ({
                 mixinsHash += '_' + value[KEYS.__hash__];
                 mixins[i] = value[KEYS.__css__];
 
+                /** replace &{...} for mixins */
+                if (mixins[i].slice(0, 2) === '&{') {
+                    mixins[i] = mixins[i].slice(2, -1);
+                }
+
                 mixinTokens.push(value);
                 Object.assign(mixinUses, value[KEYS.__use__]);
             } else {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/runtime",
-    "version": "0.0.1-alpha.55",
+    "version": "0.0.1-alpha.56",
     "description": "reshadow runtime",
     "main": "index.js",
     "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/runtime",
-    "version": "0.0.1-alpha.49",
+    "version": "0.0.1-alpha.52",
     "description": "reshadow runtime",
     "main": "index.js",
     "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/runtime",
-    "version": "0.0.1-alpha.57",
+    "version": "0.0.1-alpha.60",
     "description": "reshadow runtime",
     "main": "index.js",
     "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/runtime",
-    "version": "0.0.1-alpha.54",
+    "version": "0.0.1-alpha.55",
     "description": "reshadow runtime",
     "main": "index.js",
     "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/runtime",
-    "version": "0.0.1-alpha.56",
+    "version": "0.0.1-alpha.57",
     "description": "reshadow runtime",
     "main": "index.js",
     "repository": {
@@ -22,7 +22,7 @@
     "dependencies": {
         "@emotion/stylis": "0.8.3",
         "@emotion/unitless": "0.7.3",
-        "@reshadow/core": "^0.0.1-alpha.49",
+        "@reshadow/core": "^0.0.1-alpha.57",
         "string-hash": "^1.1.3"
     }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -20,9 +20,9 @@
         "build": "../../build.sh"
     },
     "dependencies": {
+        "@emotion/stylis": "0.8.3",
         "@emotion/unitless": "0.7.3",
         "@reshadow/core": "^0.0.1-alpha.49",
-        "string-hash": "^1.1.3",
-        "stylis": "^3.5.4"
+        "string-hash": "^1.1.3"
     }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/runtime",
-    "version": "0.0.1-alpha.60",
+    "version": "0.0.1-alpha.62",
     "description": "reshadow runtime",
     "main": "index.js",
     "repository": {
@@ -22,7 +22,7 @@
     "dependencies": {
         "@emotion/stylis": "0.8.3",
         "@emotion/unitless": "0.7.3",
-        "@reshadow/core": "^0.0.1-alpha.57",
+        "@reshadow/core": "^0.0.1-alpha.62",
         "string-hash": "^1.1.3"
     }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/runtime",
-    "version": "0.0.1-alpha.62",
+    "version": "0.0.1-alpha.63",
     "description": "reshadow runtime",
     "main": "index.js",
     "repository": {
@@ -22,7 +22,7 @@
     "dependencies": {
         "@emotion/stylis": "0.8.3",
         "@emotion/unitless": "0.7.3",
-        "@reshadow/core": "^0.0.1-alpha.62",
+        "@reshadow/core": "^0.0.1-alpha.63",
         "string-hash": "^1.1.3"
     }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/runtime",
-    "version": "0.0.1-alpha.52",
+    "version": "0.0.1-alpha.53",
     "description": "reshadow runtime",
     "main": "index.js",
     "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/runtime",
-    "version": "0.0.1-alpha.53",
+    "version": "0.0.1-alpha.54",
     "description": "reshadow runtime",
     "main": "index.js",
     "repository": {

--- a/packages/runtime/parse.js
+++ b/packages/runtime/parse.js
@@ -3,7 +3,11 @@ import stylis from 'stylis';
 
 const __root__ = '__root__';
 
-const parse = (code, hash, {isMixin, elements, attributes, classes}) => {
+const parse = (
+    code,
+    hash,
+    {isMixin, elements, attributes, onlyNamespaced, classes},
+) => {
     const options = {
         global: false,
         keyframes: !isMixin,
@@ -73,6 +77,10 @@ const parse = (code, hash, {isMixin, elements, attributes, classes}) => {
 
                         if (name[0] === '|') {
                             name = USE_PREFIX + name.slice(1);
+                        } else if (name.slice(0, 4) === 'use|') {
+                            name = USE_PREFIX + name.slice(4);
+                        } else if (onlyNamespaced) {
+                            return match;
                         }
 
                         if (value) {

--- a/packages/runtime/parse.js
+++ b/packages/runtime/parse.js
@@ -1,4 +1,4 @@
-import {USE_PREFIX} from '@reshadow/core';
+import {USE_PREFIX, KEYS} from '@reshadow/core';
 import Stylis from '@emotion/stylis';
 
 const __root__ = '__root__';
@@ -17,6 +17,7 @@ const parse = (
     stylis.set(options);
 
     const tokens = Object.create(null);
+    tokens[KEYS.__use__] = {};
     const postfix = '_' + hash;
 
     const rules = Object.create(null);
@@ -64,24 +65,36 @@ const parse = (
                 continue;
             }
 
+            let isRoot = false;
+
             selectors[i] = selector.replace(
-                /:global\((.*?)\)|\[(.*?)\]|([#.:]?\w+)/g,
-                (match, $0, $1, $2) => {
+                /:global\((.*?)\)|\[(.*?)\]|([#.:]?\w+)|([^\w])/g,
+                (match, $0, $1, $2, $3) => {
                     let className = '';
 
                     if ($0) {
                         return $0;
                     }
 
+                    if ($3) {
+                        isRoot = false;
+                        return $3;
+                    }
+
                     if ($2) {
-                        if ($2[0] === ':' || $2[0] === '#') {
+                        if ($2[0] === '#') {
+                            isRoot = false;
+                            return $2;
+                        }
+
+                        if ($2[0] === ':') {
                             return $2;
                         }
 
                         if ($2[0] === '.') {
                             className = $2.slice(1);
 
-                            let isRoot = false;
+                            isRoot = false;
                             className = className.replace(__root__, () => {
                                 isRoot = true;
                                 return postfix;
@@ -102,14 +115,24 @@ const parse = (
                     } else if ($1 && attributes) {
                         const attr = $1.replace(/[\s\n\r'"]/g, '').split('=');
                         let name = attr[0];
+                        let isModifier = false;
                         const value = attr[1];
 
                         if (name[0] === '|') {
-                            name = USE_PREFIX + name.slice(1);
+                            name = name.slice(1);
+                            isModifier = true;
                         } else if (name.slice(0, 4) === 'use|') {
-                            name = USE_PREFIX + name.slice(4);
-                        } else if (onlyNamespaced) {
+                            name = name.slice(4);
+                            isModifier = true;
+                        } else if (onlyNamespaced && !isRoot) {
                             return match;
+                        }
+
+                        if (isModifier) {
+                            tokens[KEYS.__use__][name] =
+                                tokens[KEYS.__use__][name] || {};
+                            tokens[KEYS.__use__][name][value || true] = true;
+                            name = USE_PREFIX + name;
                         }
 
                         if (value) {

--- a/packages/runtime/parse.js
+++ b/packages/runtime/parse.js
@@ -129,9 +129,9 @@ const parse = (
                         }
 
                         if (isModifier) {
-                            tokens[KEYS.__use__][name] =
-                                tokens[KEYS.__use__][name] || {};
-                            tokens[KEYS.__use__][name][value || true] = true;
+                            tokens[KEYS.__use__][
+                                name + '_' + (value || true)
+                            ] = true;
                             name = USE_PREFIX + name;
                         }
 

--- a/packages/runtime/spec/__snapshots__/index.test.js.snap
+++ b/packages/runtime/spec/__snapshots__/index.test.js.snap
@@ -2,4 +2,4 @@
 
 exports[`runtime should work with keyframes 1`] = `"_qrjiv5"`;
 
-exports[`runtime should work with keyframes 2`] = `"@-webkit-keyframes _qrjiv5{0%,25%{opacity:0;}100%{opacity:1;}}@keyframes _qrjiv5{0%,25%{opacity:0;}100%{opacity:1;}}"`;
+exports[`runtime should work with keyframes 2`] = `"@keyframes _qrjiv5{0%,25%{opacity:0;}100%{opacity:1;}}"`;

--- a/packages/styled/CHANGELOG.md
+++ b/packages/styled/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
+
+
+### Features
+
+* **runtime:** support nested elements in mixins and styled functions ([1a2ee38](https://github.com/lttb/reshadow/commit/1a2ee38))
+* **styled:** filter namespaced attributes ([b4779af](https://github.com/lttb/reshadow/commit/b4779af))
+
+
+
+
+
 ## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
 
 

--- a/packages/styled/CHANGELOG.md
+++ b/packages/styled/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
+
+
+### Features
+
+* **runtime):** move dynamic units to the runtime ([4134c07](https://github.com/lttb/reshadow/commit/4134c07))
+
+
+
+
+
 ## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
 
 

--- a/packages/styled/CHANGELOG.md
+++ b/packages/styled/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.56](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.56) (2019-06-02)
+
+
+### Bug Fixes
+
+* **runtime:** skip only null and undefined values ([1f85fdf](https://github.com/lttb/reshadow/commit/1f85fdf))
+
+
+### Features
+
+* **runtime:** move dynamic units to the runtime ([965ec27](https://github.com/lttb/reshadow/commit/965ec27))
+
+
+
+
+
 ## [0.0.1-alpha.55](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.54...v0.0.1-alpha.55) (2019-06-02)
 
 

--- a/packages/styled/CHANGELOG.md
+++ b/packages/styled/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
+
+
+### Features
+
+* **styled:** move units to the dynamic values ([c13cbb7](https://github.com/lttb/reshadow/commit/c13cbb7))
+* **styled:** process only namespaced attributes ([72cc2d5](https://github.com/lttb/reshadow/commit/72cc2d5))
+
+
+
+
+
 ## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
 
 

--- a/packages/styled/CHANGELOG.md
+++ b/packages/styled/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.54](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.53...v0.0.1-alpha.54) (2019-06-02)
+
+
+### Features
+
+* **runtime:** use @emotion/stylis, merge mixins into the class to avoid specificity ([e43e634](https://github.com/lttb/reshadow/commit/e43e634))
+
+
+
+
+
 ## [0.0.1-alpha.53](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.52...v0.0.1-alpha.53) (2019-06-02)
 
 

--- a/packages/styled/CHANGELOG.md
+++ b/packages/styled/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/styled
+
+
+
+
+
 ## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
 
 

--- a/packages/styled/CHANGELOG.md
+++ b/packages/styled/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.60](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.59...v0.0.1-alpha.60) (2019-06-03)
+
+
+### Bug Fixes
+
+* **runtime:** fix mixins apply order ([1584d66](https://github.com/lttb/reshadow/commit/1584d66))
+
+
+
+
+
 ## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
 
 

--- a/packages/styled/CHANGELOG.md
+++ b/packages/styled/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.63](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.62...v0.0.1-alpha.63) (2019-06-04)
+
+**Note:** Version bump only for package @reshadow/styled
+
+
+
+
+
 ## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/styled

--- a/packages/styled/CHANGELOG.md
+++ b/packages/styled/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.52](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.51...v0.0.1-alpha.52) (2019-06-02)
+
+
+### Bug Fixes
+
+* **runtime:** fix mixin detection ([86d2193](https://github.com/lttb/reshadow/commit/86d2193))
+
+
+
+
+
 ## [0.0.1-alpha.49](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.48...v0.0.1-alpha.49) (2019-05-31)
 
 **Note:** Version bump only for package @reshadow/styled

--- a/packages/styled/index.js
+++ b/packages/styled/index.js
@@ -81,7 +81,7 @@ function css() {
     };
 }
 
-const reshadowStyled = createReshadowStyled((element, as, props) => {
+const reshadowStyled = createReshadowStyled((element, as, props, filtered) => {
     let style = coreStyled[KEYS.__style__];
 
     if (style) {
@@ -89,6 +89,12 @@ const reshadowStyled = createReshadowStyled((element, as, props) => {
     }
 
     props = map(element, props);
+
+    if (filtered) {
+        for (let i = 0; i < filtered.length; i++) {
+            delete props[filtered[i]];
+        }
+    }
 
     const result = React.createElement(as, props);
 
@@ -106,6 +112,12 @@ const createStyled = tag => {
         const isComponent = typeof tag !== 'string';
         const element = isComponent ? getDisplayName(tag) : tag;
         const elementClassName = '.__root__';
+
+        if (typeof strs === 'function') {
+            values = [strs];
+            strs = ['', ''];
+        }
+
         const wrapper = (options.wrap || wrap)(elementClassName, [...strs]);
 
         class StyledComponent extends React.Component {
@@ -165,18 +177,13 @@ const createStyled = tag => {
 
                 args.push.apply(args, localValues);
 
-                if (!isComponent) {
-                    for (let i = 0; i < filtered.length; i++) {
-                        delete props[filtered[i]];
-                    }
-                }
-
                 props.ref = $$ref;
 
                 return (options.styled || reshadowStyled).apply(null, args)(
                     'root__',
                     as,
                     props,
+                    !isComponent && filtered,
                 );
             }
 
@@ -223,7 +230,7 @@ tags.forEach(tag => {
 });
 
 export * from 'theming';
-export {createGlobalStyle} from './global';
+export {createGlobalStyle} from '@reshadow/styled/global';
 
 export function isStyledComponent(target) {
     return target && typeof target.styledComponentId === 'string';

--- a/packages/styled/index.js
+++ b/packages/styled/index.js
@@ -6,7 +6,7 @@ import {
     wrap,
     createCSS,
 } from '@reshadow/runtime';
-import coreStyled, {KEYS, map} from '@reshadow/core';
+import coreStyled, {KEYS, map, use} from '@reshadow/core';
 import tags from '@reshadow/utils/html-tags';
 import {ThemeContext} from 'theming';
 import isReactProp from 'is-react-prop';
@@ -31,6 +31,8 @@ const filterProps = props => {
 const __css__ = createCSS({
     elements: false,
     classes: false,
+    attributes: true,
+    onlyNamespaced: true,
 });
 
 const re = /\w+:[\s\r\n]*$/;
@@ -79,7 +81,9 @@ const reshadowStyled = createReshadowStyled((element, as, props) => {
         props.style = Object.assign({}, style, props.style);
     }
 
-    const result = React.createElement(as, map(element, props));
+    Object.assign(props, map(element, use(props)));
+
+    const result = React.createElement(as, props);
 
     if (style && result.props.style === props.style) {
         return result;

--- a/packages/styled/index.js
+++ b/packages/styled/index.js
@@ -6,7 +6,7 @@ import {
     wrap,
     createCSS,
 } from '@reshadow/runtime';
-import coreStyled, {KEYS, map, use} from '@reshadow/core';
+import coreStyled, {KEYS, map} from '@reshadow/core';
 import tags from '@reshadow/utils/html-tags';
 import {ThemeContext} from 'theming';
 import isReactProp from 'is-react-prop';
@@ -88,7 +88,7 @@ const reshadowStyled = createReshadowStyled((element, as, props) => {
         props.style = Object.assign({}, style, props.style);
     }
 
-    Object.assign(props, map(element, use(props)));
+    props = map(element, props);
 
     const result = React.createElement(as, props);
 

--- a/packages/styled/index.js
+++ b/packages/styled/index.js
@@ -35,7 +35,6 @@ const __css__ = createCSS({
     onlyNamespaced: true,
 });
 
-const unitRe = /^[\s\n\r]*(cm|mm|in|px|pt|pc|em|ex|ch|rem|vw|vh|vmin|vmax|%)[\s\n\r]*[,;)]/;
 const mixin = value => {
     if (value[0] === "'" || value[0] === '"' || value.indexOf(':') === -1) {
         return value;
@@ -47,27 +46,16 @@ const mixin = value => {
 function css() {
     const str = [...arguments[0]];
     const functions = {};
-    const functionUnits = {};
     const args = [str];
 
     for (let i = 1, len = arguments.length; i < len; i++) {
         const value = arguments[i];
         args[i] = value;
-        const matchUnit = str[i] && str[i].match(unitRe);
+
         if (typeof value === 'function') {
             functions[i] = value;
         } else if (typeof value === 'string') {
             args[i] = mixin(value);
-        }
-        if (matchUnit) {
-            if (functions[i]) {
-                functionUnits[i] = matchUnit[1];
-            } else {
-                args[i] += matchUnit[1];
-            }
-
-            const match = matchUnit[0];
-            str[i] = match[match.length - 1] + str[i].slice(match.length);
         }
     }
 
@@ -86,10 +74,6 @@ function css() {
             }
 
             while (typeof value === 'function') value = value(data);
-
-            if (functionUnits[index]) {
-                value += functionUnits[index];
-            }
 
             nextArgs[index] = value;
         }

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/styled",
-    "version": "0.0.1-alpha.60",
+    "version": "0.0.1-alpha.62",
     "description": "reshadow styled-components API",
     "main": "index.js",
     "repository": {
@@ -20,9 +20,9 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/core": "^0.0.1-alpha.57",
-        "@reshadow/react": "^0.0.1-alpha.60",
-        "@reshadow/runtime": "^0.0.1-alpha.60",
+        "@reshadow/core": "^0.0.1-alpha.62",
+        "@reshadow/react": "^0.0.1-alpha.62",
+        "@reshadow/runtime": "^0.0.1-alpha.62",
         "@reshadow/utils": "0.0.1-alpha.30",
         "is-react-prop": "1.0.0",
         "stylis": "3.5.4",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/styled",
-    "version": "0.0.1-alpha.57",
+    "version": "0.0.1-alpha.60",
     "description": "reshadow styled-components API",
     "main": "index.js",
     "repository": {
@@ -21,8 +21,8 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.57",
-        "@reshadow/react": "^0.0.1-alpha.57",
-        "@reshadow/runtime": "^0.0.1-alpha.57",
+        "@reshadow/react": "^0.0.1-alpha.60",
+        "@reshadow/runtime": "^0.0.1-alpha.60",
         "@reshadow/utils": "0.0.1-alpha.30",
         "is-react-prop": "1.0.0",
         "stylis": "3.5.4",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/styled",
-    "version": "0.0.1-alpha.54",
+    "version": "0.0.1-alpha.55",
     "description": "reshadow styled-components API",
     "main": "index.js",
     "repository": {
@@ -21,8 +21,8 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/react": "^0.0.1-alpha.54",
-        "@reshadow/runtime": "^0.0.1-alpha.54",
+        "@reshadow/react": "^0.0.1-alpha.55",
+        "@reshadow/runtime": "^0.0.1-alpha.55",
         "@reshadow/utils": "0.0.1-alpha.30",
         "is-react-prop": "1.0.0",
         "stylis": "3.5.4",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/styled",
-    "version": "0.0.1-alpha.55",
+    "version": "0.0.1-alpha.56",
     "description": "reshadow styled-components API",
     "main": "index.js",
     "repository": {
@@ -21,8 +21,8 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/react": "^0.0.1-alpha.55",
-        "@reshadow/runtime": "^0.0.1-alpha.55",
+        "@reshadow/react": "^0.0.1-alpha.56",
+        "@reshadow/runtime": "^0.0.1-alpha.56",
         "@reshadow/utils": "0.0.1-alpha.30",
         "is-react-prop": "1.0.0",
         "stylis": "3.5.4",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/styled",
-    "version": "0.0.1-alpha.52",
+    "version": "0.0.1-alpha.53",
     "description": "reshadow styled-components API",
     "main": "index.js",
     "repository": {
@@ -21,8 +21,8 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/react": "^0.0.1-alpha.52",
-        "@reshadow/runtime": "^0.0.1-alpha.52",
+        "@reshadow/react": "^0.0.1-alpha.53",
+        "@reshadow/runtime": "^0.0.1-alpha.53",
         "@reshadow/utils": "0.0.1-alpha.30",
         "is-react-prop": "1.0.0",
         "stylis": "3.5.4",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/styled",
-    "version": "0.0.1-alpha.53",
+    "version": "0.0.1-alpha.54",
     "description": "reshadow styled-components API",
     "main": "index.js",
     "repository": {
@@ -21,8 +21,8 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/react": "^0.0.1-alpha.53",
-        "@reshadow/runtime": "^0.0.1-alpha.53",
+        "@reshadow/react": "^0.0.1-alpha.54",
+        "@reshadow/runtime": "^0.0.1-alpha.54",
         "@reshadow/utils": "0.0.1-alpha.30",
         "is-react-prop": "1.0.0",
         "stylis": "3.5.4",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/styled",
-    "version": "0.0.1-alpha.49",
+    "version": "0.0.1-alpha.52",
     "description": "reshadow styled-components API",
     "main": "index.js",
     "repository": {
@@ -21,8 +21,8 @@
     },
     "dependencies": {
         "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/react": "^0.0.1-alpha.49",
-        "@reshadow/runtime": "^0.0.1-alpha.49",
+        "@reshadow/react": "^0.0.1-alpha.52",
+        "@reshadow/runtime": "^0.0.1-alpha.52",
         "@reshadow/utils": "0.0.1-alpha.30",
         "is-react-prop": "1.0.0",
         "stylis": "3.5.4",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/styled",
-    "version": "0.0.1-alpha.56",
+    "version": "0.0.1-alpha.57",
     "description": "reshadow styled-components API",
     "main": "index.js",
     "repository": {
@@ -20,9 +20,9 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/core": "^0.0.1-alpha.49",
-        "@reshadow/react": "^0.0.1-alpha.56",
-        "@reshadow/runtime": "^0.0.1-alpha.56",
+        "@reshadow/core": "^0.0.1-alpha.57",
+        "@reshadow/react": "^0.0.1-alpha.57",
+        "@reshadow/runtime": "^0.0.1-alpha.57",
         "@reshadow/utils": "0.0.1-alpha.30",
         "is-react-prop": "1.0.0",
         "stylis": "3.5.4",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/styled",
-    "version": "0.0.1-alpha.62",
+    "version": "0.0.1-alpha.63",
     "description": "reshadow styled-components API",
     "main": "index.js",
     "repository": {
@@ -20,9 +20,9 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/core": "^0.0.1-alpha.62",
-        "@reshadow/react": "^0.0.1-alpha.62",
-        "@reshadow/runtime": "^0.0.1-alpha.62",
+        "@reshadow/core": "^0.0.1-alpha.63",
+        "@reshadow/react": "^0.0.1-alpha.63",
+        "@reshadow/runtime": "^0.0.1-alpha.63",
         "@reshadow/utils": "0.0.1-alpha.30",
         "is-react-prop": "1.0.0",
         "stylis": "3.5.4",

--- a/packages/styled/spec/__snapshots__/index.test.js.snap
+++ b/packages/styled/spec/__snapshots__/index.test.js.snap
@@ -45,6 +45,26 @@ exports[`styled should create global style 1`] = `null`;
 
 exports[`styled should create global style 2`] = `"body{color:var(--10pagwf_1);}"`;
 
+exports[`styled should process only namespaced attributes 1`] = `
+<button
+  class="_13armfq _use--size_m_13armfq"
+>
+  click me
+</button>
+`;
+
+exports[`styled should process only namespaced attributes 2`] = `"._13armfq{color:red;}._13armfq._use--size_m_13armfq{font-size:14px;}._13armfq._use--size_s_13armfq{font-size:14px;}._13armfq[disabled]{opacity:0.5;}"`;
+
+exports[`styled should process only namespaced attributes 3`] = `
+<button
+  class="_13armfq _use--size_s_13armfq"
+>
+  click me
+</button>
+`;
+
+exports[`styled should process only namespaced attributes 4`] = `"._13armfq{color:red;}._13armfq._use--size_m_13armfq{font-size:14px;}._13armfq._use--size_s_13armfq{font-size:14px;}._13armfq[disabled]{opacity:0.5;}"`;
+
 exports[`styled should work with as 1`] = `
 <a
   class="_sna6ae"

--- a/packages/styled/spec/__snapshots__/index.test.js.snap
+++ b/packages/styled/spec/__snapshots__/index.test.js.snap
@@ -56,25 +56,36 @@ exports[`styled should deal with specificity 1`] = `
 
 exports[`styled should deal with specificity 2`] = `"._12w6gee:after{-webkit-flex:1;-ms-flex:1;flex:1;-webkit-flex:var(--egcu4c_2);-ms-flex:var(--egcu4c_2);flex:var(--egcu4c_2);}._12w6gee:before{-webkit-flex:1;-ms-flex:1;flex:1;-webkit-flex:var(--egcu4c_4);-ms-flex:var(--egcu4c_4);flex:var(--egcu4c_4);}"`;
 
-exports[`styled should process only namespaced attributes 1`] = `
+exports[`styled should process namespaced attributes and dont pass them 1`] = `
 <button
-  class="_13armfq _use--size_m_13armfq"
+  class="_zgczid _use--disabled_zgczid _use--size_m_zgczid"
 >
   click me
 </button>
 `;
 
-exports[`styled should process only namespaced attributes 2`] = `"._13armfq._use--size_m_13armfq{font-size:14px;}._13armfq._use--size_s_13armfq{font-size:14px;}._13armfq[disabled]{opacity:0.5;}._13armfq{color:red;}"`;
+exports[`styled should process namespaced attributes and dont pass them 2`] = `"._zgczid._use--size_m_zgczid{font-size:14px;}._zgczid._use--size_s_zgczid{font-size:14px;}._zgczid._use--disabled_zgczid{opacity:0.5;}._zgczid{color:red;}"`;
 
-exports[`styled should process only namespaced attributes 3`] = `
+exports[`styled should process namespaced attributes and dont pass them 3`] = `
 <button
-  class="_13armfq _use--size_s_13armfq"
+  class="_zgczid _use--disabled_zgczid _use--size_s_zgczid"
 >
   click me
 </button>
 `;
 
-exports[`styled should process only namespaced attributes 4`] = `"._13armfq._use--size_m_13armfq{font-size:14px;}._13armfq._use--size_s_13armfq{font-size:14px;}._13armfq[disabled]{opacity:0.5;}._13armfq{color:red;}"`;
+exports[`styled should process namespaced attributes and dont pass them 4`] = `"._zgczid._use--size_m_zgczid{font-size:14px;}._zgczid._use--size_s_zgczid{font-size:14px;}._zgczid._use--disabled_zgczid{opacity:0.5;}._zgczid{color:red;}"`;
+
+exports[`styled should process root props 1`] = `
+<button
+  class="_zdj1v2 _disabled_zdj1v2"
+  disabled=""
+>
+  click me
+</button>
+`;
+
+exports[`styled should process root props 2`] = `"._zdj1v2._disabled_zdj1v2 + [disabled] + ._zdj1v2._disabled_zdj1v2{opacity:0.5;}"`;
 
 exports[`styled should work with as 1`] = `
 <a

--- a/packages/styled/spec/__snapshots__/index.test.js.snap
+++ b/packages/styled/spec/__snapshots__/index.test.js.snap
@@ -101,14 +101,14 @@ exports[`styled should work with css prop with tagged literal 2`] = `"._1eg04s3{
 
 exports[`styled should work with mixins 1`] = `
 <button
-  class="_zzt5ow"
-  style="--1cxyzr1_2:red"
+  class="_wopuxb"
+  style="--1txtmwt_4:red"
 >
   click me
 </button>
 `;
 
-exports[`styled should work with mixins 2`] = `"._zzt5ow{color:var(--1cxyzr1_2);}._zzt5ow{padding:10px;}"`;
+exports[`styled should work with mixins 2`] = `"._wopuxb{color:var(--1txtmwt_4);}._wopuxb{padding:10px;}._wopuxb::after{content:'';}._wopuxb::before{content:'';}"`;
 
 exports[`styled should work with nested mixins 1`] = `
 <button

--- a/packages/styled/spec/__snapshots__/index.test.js.snap
+++ b/packages/styled/spec/__snapshots__/index.test.js.snap
@@ -143,15 +143,15 @@ exports[`styled should work with mixins 2`] = `"._wopuxb{padding:10px;color:var(
 
 exports[`styled should work with mixins as strings 1`] = `
 <button
-  class="_1g58xwt"
-  style="--11qe8pu_1:-200px;--11qe8pu_2:100px"
+  class="_q0rwq0"
+  style="--auziqq_1:-200px;--auziqq_2:100px"
   width="100"
 >
   click me
 </button>
 `;
 
-exports[`styled should work with mixins as strings 2`] = `"._1g58xwt{padding:10px;-webkit-transform:translateX(var(--11qe8pu_1));-ms-transform:translateX(var(--11qe8pu_1));transform:translateX(var(--11qe8pu_1));margin:var(--11qe8pu_2);}"`;
+exports[`styled should work with mixins as strings 2`] = `"._q0rwq0{padding:10px;-webkit-transform:translateX(var(--auziqq_1));-ms-transform:translateX(var(--auziqq_1));transform:translateX(var(--auziqq_1));margin:var(--auziqq_2);}"`;
 
 exports[`styled should work with nested mixins 1`] = `
 <button

--- a/packages/styled/spec/__snapshots__/index.test.js.snap
+++ b/packages/styled/spec/__snapshots__/index.test.js.snap
@@ -229,3 +229,14 @@ exports[`styled should work with theme 1`] = `
 `;
 
 exports[`styled should work with theme 2`] = `"._sna6ae{color:var(--1v6vp2v_1);}"`;
+
+exports[`styled supports function interface 1`] = `
+<button
+  class="_51xj47 _use--color_1ntyugu"
+  style="--ajx7i6_1:red"
+>
+  click me
+</button>
+`;
+
+exports[`styled supports function interface 2`] = `"._51xj47._use--color_1ntyugu{color:var(--ajx7i6_1);}"`;

--- a/packages/styled/spec/__snapshots__/index.test.js.snap
+++ b/packages/styled/spec/__snapshots__/index.test.js.snap
@@ -47,14 +47,15 @@ exports[`styled should create global style 2`] = `"body{color:var(--10pagwf_1);}
 
 exports[`styled should deal with specificity 1`] = `
 <h4
-  class="_12w6gee"
-  style="--egcu4c_2:20;--egcu4c_4:20"
+  class="_1or1rjp"
+  color="red"
+  style="--6s77bw_2:20;--2smzwp_2:red;--6s77bw_5:20"
 >
   title
 </h4>
 `;
 
-exports[`styled should deal with specificity 2`] = `"._12w6gee:after{-webkit-flex:1;-ms-flex:1;flex:1;-webkit-flex:var(--egcu4c_2);-ms-flex:var(--egcu4c_2);flex:var(--egcu4c_2);}._12w6gee:before{-webkit-flex:1;-ms-flex:1;flex:1;-webkit-flex:var(--egcu4c_4);-ms-flex:var(--egcu4c_4);flex:var(--egcu4c_4);}"`;
+exports[`styled should deal with specificity 2`] = `"._1or1rjp::after{-webkit-flex:1;-ms-flex:1;flex:1;-webkit-flex:var(--6s77bw_2);-ms-flex:var(--6s77bw_2);flex:var(--6s77bw_2);-webkit-flex:1;-ms-flex:1;flex:1;border-radius:1rem;background-color:var(--2smzwp_2);}._1or1rjp::before{-webkit-flex:1;-ms-flex:1;flex:1;-webkit-flex:var(--2smzwp_2);-ms-flex:var(--2smzwp_2);flex:var(--2smzwp_2);-webkit-flex:1;-ms-flex:1;flex:1;border-radius:1rem;background-color:var(--2smzwp_2);}"`;
 
 exports[`styled should process namespaced attributes and dont pass them 1`] = `
 <button
@@ -117,7 +118,7 @@ exports[`styled should work with css prop 1`] = `
 </button>
 `;
 
-exports[`styled should work with css prop 2`] = `"._1eg04s3{padding:5px 10px;color:var(--1v6vp2v_1);}"`;
+exports[`styled should work with css prop 2`] = `"._1eg04s3{color:var(--1v6vp2v_1);padding:5px 10px;}"`;
 
 exports[`styled should work with css prop function 1`] = `
 <button
@@ -128,7 +129,7 @@ exports[`styled should work with css prop function 1`] = `
 </button>
 `;
 
-exports[`styled should work with css prop function 2`] = `"._1eg04s3{padding:5px 10px;color:var(--1v6vp2v_1);}"`;
+exports[`styled should work with css prop function 2`] = `"._1eg04s3{color:var(--1v6vp2v_1);padding:5px 10px;}"`;
 
 exports[`styled should work with css prop with tagged literal 1`] = `
 <button
@@ -139,7 +140,7 @@ exports[`styled should work with css prop with tagged literal 1`] = `
 </button>
 `;
 
-exports[`styled should work with css prop with tagged literal 2`] = `"._1eg04s3{padding:5px 10px;color:var(--1v6vp2v_1);}"`;
+exports[`styled should work with css prop with tagged literal 2`] = `"._1eg04s3{color:var(--1v6vp2v_1);padding:5px 10px;}"`;
 
 exports[`styled should work with dynamic mixins 1`] = `
 <button
@@ -174,7 +175,7 @@ exports[`styled should work with mixins 1`] = `
 </button>
 `;
 
-exports[`styled should work with mixins 2`] = `"._wopuxb{padding:10px;color:var(--1txtmwt_4);}._wopuxb::after{content:'';}._wopuxb::before{content:'';}"`;
+exports[`styled should work with mixins 2`] = `"._wopuxb::after{content:'';}._wopuxb::before{content:'';}._wopuxb{padding:10px;color:var(--1txtmwt_4);}"`;
 
 exports[`styled should work with nested mixins 1`] = `
 <button

--- a/packages/styled/spec/__snapshots__/index.test.js.snap
+++ b/packages/styled/spec/__snapshots__/index.test.js.snap
@@ -130,6 +130,30 @@ exports[`styled should work with css prop with tagged literal 1`] = `
 
 exports[`styled should work with css prop with tagged literal 2`] = `"._1eg04s3{padding:5px 10px;color:var(--1v6vp2v_1);}"`;
 
+exports[`styled should work with dynamic mixins 1`] = `
+<button
+  class="_miwxjj"
+  style="--auziqq_1:-0px;--auziqq_2:0px"
+  width="0"
+>
+  click me
+</button>
+`;
+
+exports[`styled should work with dynamic mixins 2`] = `"._miwxjj{-webkit-transform:translateX(var(--auziqq_1));-ms-transform:translateX(var(--auziqq_1));transform:translateX(var(--auziqq_1));margin:var(--auziqq_2);}"`;
+
+exports[`styled should work with dynamic mixins 3`] = `
+<button
+  class="_miwxjj"
+  style="--auziqq_1:-200px;--auziqq_2:100px"
+  width="100"
+>
+  click me
+</button>
+`;
+
+exports[`styled should work with dynamic mixins 4`] = `"._miwxjj{-webkit-transform:translateX(var(--auziqq_1));-ms-transform:translateX(var(--auziqq_1));transform:translateX(var(--auziqq_1));margin:var(--auziqq_2);}"`;
+
 exports[`styled should work with mixins 1`] = `
 <button
   class="_wopuxb"
@@ -140,18 +164,6 @@ exports[`styled should work with mixins 1`] = `
 `;
 
 exports[`styled should work with mixins 2`] = `"._wopuxb{padding:10px;color:var(--1txtmwt_4);}._wopuxb::after{content:'';}._wopuxb::before{content:'';}"`;
-
-exports[`styled should work with mixins as strings 1`] = `
-<button
-  class="_q0rwq0"
-  style="--auziqq_1:-200px;--auziqq_2:100px"
-  width="100"
->
-  click me
-</button>
-`;
-
-exports[`styled should work with mixins as strings 2`] = `"._q0rwq0{padding:10px;-webkit-transform:translateX(var(--auziqq_1));-ms-transform:translateX(var(--auziqq_1));transform:translateX(var(--auziqq_1));margin:var(--auziqq_2);}"`;
 
 exports[`styled should work with nested mixins 1`] = `
 <button
@@ -184,6 +196,17 @@ exports[`styled should work with nested mixins 5`] = `
 `;
 
 exports[`styled should work with nested mixins 6`] = `"._4ykgti{color:var(--pjcj95_1);}._g1uhfs{color:blue;}"`;
+
+exports[`styled should work with string mixins 1`] = `
+<button
+  class="_zip2hf"
+  width="100"
+>
+  click me
+</button>
+`;
+
+exports[`styled should work with string mixins 2`] = `"._zip2hf{padding:10px;}"`;
 
 exports[`styled should work with theme 1`] = `
 <button

--- a/packages/styled/spec/__snapshots__/index.test.js.snap
+++ b/packages/styled/spec/__snapshots__/index.test.js.snap
@@ -19,7 +19,7 @@ exports[`styled should apply nested styles 1`] = `
 </button>
 `;
 
-exports[`styled should apply nested styles 2`] = `"._5jpyup{color:red;}._5jpyup span{margin-right:10px;}"`;
+exports[`styled should apply nested styles 2`] = `"._5jpyup span{margin-right:10px;}._5jpyup{color:red;}"`;
 
 exports[`styled should apply styles 1`] = `
 <button
@@ -45,6 +45,17 @@ exports[`styled should create global style 1`] = `null`;
 
 exports[`styled should create global style 2`] = `"body{color:var(--10pagwf_1);}"`;
 
+exports[`styled should deal with specificity 1`] = `
+<h4
+  class="_12w6gee"
+  style="--egcu4c_2:20;--egcu4c_4:20"
+>
+  title
+</h4>
+`;
+
+exports[`styled should deal with specificity 2`] = `"._12w6gee:after{-webkit-flex:1;-ms-flex:1;flex:1;-webkit-flex:var(--egcu4c_2);-ms-flex:var(--egcu4c_2);flex:var(--egcu4c_2);}._12w6gee:before{-webkit-flex:1;-ms-flex:1;flex:1;-webkit-flex:var(--egcu4c_4);-ms-flex:var(--egcu4c_4);flex:var(--egcu4c_4);}"`;
+
 exports[`styled should process only namespaced attributes 1`] = `
 <button
   class="_13armfq _use--size_m_13armfq"
@@ -53,7 +64,7 @@ exports[`styled should process only namespaced attributes 1`] = `
 </button>
 `;
 
-exports[`styled should process only namespaced attributes 2`] = `"._13armfq{color:red;}._13armfq._use--size_m_13armfq{font-size:14px;}._13armfq._use--size_s_13armfq{font-size:14px;}._13armfq[disabled]{opacity:0.5;}"`;
+exports[`styled should process only namespaced attributes 2`] = `"._13armfq._use--size_m_13armfq{font-size:14px;}._13armfq._use--size_s_13armfq{font-size:14px;}._13armfq[disabled]{opacity:0.5;}._13armfq{color:red;}"`;
 
 exports[`styled should process only namespaced attributes 3`] = `
 <button
@@ -63,7 +74,7 @@ exports[`styled should process only namespaced attributes 3`] = `
 </button>
 `;
 
-exports[`styled should process only namespaced attributes 4`] = `"._13armfq{color:red;}._13armfq._use--size_m_13armfq{font-size:14px;}._13armfq._use--size_s_13armfq{font-size:14px;}._13armfq[disabled]{opacity:0.5;}"`;
+exports[`styled should process only namespaced attributes 4`] = `"._13armfq._use--size_m_13armfq{font-size:14px;}._13armfq._use--size_s_13armfq{font-size:14px;}._13armfq[disabled]{opacity:0.5;}._13armfq{color:red;}"`;
 
 exports[`styled should work with as 1`] = `
 <a
@@ -95,7 +106,7 @@ exports[`styled should work with css prop 1`] = `
 </button>
 `;
 
-exports[`styled should work with css prop 2`] = `"._1eg04s3{color:var(--1v6vp2v_1);}._1eg04s3{padding:5px 10px;}"`;
+exports[`styled should work with css prop 2`] = `"._1eg04s3{padding:5px 10px;color:var(--1v6vp2v_1);}"`;
 
 exports[`styled should work with css prop function 1`] = `
 <button
@@ -106,7 +117,7 @@ exports[`styled should work with css prop function 1`] = `
 </button>
 `;
 
-exports[`styled should work with css prop function 2`] = `"._1eg04s3{color:var(--1v6vp2v_1);}._1eg04s3{padding:5px 10px;}"`;
+exports[`styled should work with css prop function 2`] = `"._1eg04s3{padding:5px 10px;color:var(--1v6vp2v_1);}"`;
 
 exports[`styled should work with css prop with tagged literal 1`] = `
 <button
@@ -117,7 +128,7 @@ exports[`styled should work with css prop with tagged literal 1`] = `
 </button>
 `;
 
-exports[`styled should work with css prop with tagged literal 2`] = `"._1eg04s3{color:var(--1v6vp2v_1);}._1eg04s3{padding:5px 10px;}"`;
+exports[`styled should work with css prop with tagged literal 2`] = `"._1eg04s3{padding:5px 10px;color:var(--1v6vp2v_1);}"`;
 
 exports[`styled should work with mixins 1`] = `
 <button
@@ -128,7 +139,7 @@ exports[`styled should work with mixins 1`] = `
 </button>
 `;
 
-exports[`styled should work with mixins 2`] = `"._wopuxb{color:var(--1txtmwt_4);}._wopuxb{padding:10px;}._wopuxb::after{content:'';}._wopuxb::before{content:'';}"`;
+exports[`styled should work with mixins 2`] = `"._wopuxb{padding:10px;color:var(--1txtmwt_4);}._wopuxb::after{content:'';}._wopuxb::before{content:'';}"`;
 
 exports[`styled should work with mixins as strings 1`] = `
 <button
@@ -140,7 +151,7 @@ exports[`styled should work with mixins as strings 1`] = `
 </button>
 `;
 
-exports[`styled should work with mixins as strings 2`] = `"._1g58xwt{padding:10px;}._1g58xwt{-webkit-transform:translateX(var(--11qe8pu_1));-ms-transform:translateX(var(--11qe8pu_1));transform:translateX(var(--11qe8pu_1));margin:var(--11qe8pu_2);}"`;
+exports[`styled should work with mixins as strings 2`] = `"._1g58xwt{padding:10px;-webkit-transform:translateX(var(--11qe8pu_1));-ms-transform:translateX(var(--11qe8pu_1));transform:translateX(var(--11qe8pu_1));margin:var(--11qe8pu_2);}"`;
 
 exports[`styled should work with nested mixins 1`] = `
 <button

--- a/packages/styled/spec/__snapshots__/index.test.js.snap
+++ b/packages/styled/spec/__snapshots__/index.test.js.snap
@@ -130,6 +130,18 @@ exports[`styled should work with mixins 1`] = `
 
 exports[`styled should work with mixins 2`] = `"._wopuxb{color:var(--1txtmwt_4);}._wopuxb{padding:10px;}._wopuxb::after{content:'';}._wopuxb::before{content:'';}"`;
 
+exports[`styled should work with mixins as strings 1`] = `
+<button
+  class="_1g58xwt"
+  style="--11qe8pu_1:-200px;--11qe8pu_2:100px"
+  width="100"
+>
+  click me
+</button>
+`;
+
+exports[`styled should work with mixins as strings 2`] = `"._1g58xwt{padding:10px;}._1g58xwt{-webkit-transform:translateX(var(--11qe8pu_1));-ms-transform:translateX(var(--11qe8pu_1));transform:translateX(var(--11qe8pu_1));margin:var(--11qe8pu_2);}"`;
+
 exports[`styled should work with nested mixins 1`] = `
 <button
   class="_4ykgti"

--- a/packages/styled/spec/index.test.js
+++ b/packages/styled/spec/index.test.js
@@ -288,19 +288,29 @@ describe('styled', () => {
             flex: 1;
         `;
 
+        const isBadge = ({color}) =>
+            color &&
+            css`
+                ${style}
+                border-radius: 1rem;
+                background-color: ${({color}) => color};
+            `;
+
         const Wrap = styled(({start, end, max, ...props}) => <h4 {...props} />)`
-            :after {
+            ::after {
                 ${style};
                 flex: ${({start}) => start && '20'};
+                ${isBadge}
             }
-            :before {
+            ::before {
                 ${style};
                 flex: ${({end}) => end && '20'};
+                ${isBadge}
             }
         `;
 
         const wrapper = render(
-            <Wrap start end>
+            <Wrap color="red" start end>
                 title
             </Wrap>,
         );

--- a/packages/styled/spec/index.test.js
+++ b/packages/styled/spec/index.test.js
@@ -52,7 +52,19 @@ describe('styled', () => {
         expect(getStyles()).toMatchSnapshot();
     });
 
-    it('should process only namespaced attributes', () => {
+    it('should process root props', () => {
+        const Button = styled.button`
+            &[disabled] + [disabled] + &[disabled] {
+                opacity: 0.5;
+            }
+        `;
+
+        const wrapper = shallow(<Button disabled>click me</Button>);
+        expect(wrapper.render()).toMatchSnapshot();
+        expect(getStyles()).toMatchSnapshot();
+    });
+
+    it('should process namespaced attributes and dont pass them', () => {
         const Button = styled.button`
             color: red;
 
@@ -64,14 +76,14 @@ describe('styled', () => {
                 font-size: 14px;
             }
 
-            &[disabled] {
+            &[|disabled] {
                 opacity: 0.5;
             }
         `;
 
         Button.defaultProps = {size: 'm'};
 
-        const wrapper = shallow(<Button>click me</Button>);
+        const wrapper = shallow(<Button disabled>click me</Button>);
         expect(wrapper.render()).toMatchSnapshot();
         expect(getStyles()).toMatchSnapshot();
 

--- a/packages/styled/spec/index.test.js
+++ b/packages/styled/spec/index.test.js
@@ -235,6 +235,28 @@ describe('styled', () => {
         expect(getStyles()).toMatchSnapshot();
     });
 
+    it('should work with mixins as strings', () => {
+        const padding = `
+            padding: 10px;
+        `;
+
+        const dynamicMixin = ({width}) =>
+            css`
+                transform: translateX(${({width}) => `-${2 * width}`}px);
+                margin: ${width}px;
+            `;
+
+        const Button = styled.button`
+            ${padding}
+            ${dynamicMixin}
+        `;
+
+        const wrapper = render(<Button width={100}>click me</Button>);
+
+        expect(wrapper).toMatchSnapshot();
+        expect(getStyles()).toMatchSnapshot();
+    });
+
     it('should work with nested mixins', () => {
         const complexMixin = css`
             color: ${props => (props.whiteColor ? 'white' : 'black')};

--- a/packages/styled/spec/index.test.js
+++ b/packages/styled/spec/index.test.js
@@ -257,6 +257,32 @@ describe('styled', () => {
         expect(getStyles()).toMatchSnapshot();
     });
 
+    it('should deal with specificity', () => {
+        const style = css`
+            flex: 1;
+        `;
+
+        const Wrap = styled(({start, end, max, ...props}) => <h4 {...props} />)`
+            :after {
+                ${style};
+                flex: ${({start}) => start && '20'};
+            }
+            :before {
+                ${style};
+                flex: ${({end}) => end && '20'};
+            }
+        `;
+
+        const wrapper = render(
+            <Wrap start end>
+                title
+            </Wrap>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(getStyles()).toMatchSnapshot();
+    });
+
     it('should work with nested mixins', () => {
         const complexMixin = css`
             color: ${props => (props.whiteColor ? 'white' : 'black')};

--- a/packages/styled/spec/index.test.js
+++ b/packages/styled/spec/index.test.js
@@ -344,4 +344,18 @@ describe('styled', () => {
         expect(wrapper.render()).toMatchSnapshot();
         expect(getStyles()).toMatchSnapshot();
     });
+
+    it('supports function interface', () => {
+        const Button = styled.button(
+            props => css`
+                &[|color] {
+                    color: ${props.color};
+                }
+            `,
+        );
+
+        const wrapper = shallow(<Button color="red">click me</Button>);
+        expect(wrapper.render()).toMatchSnapshot();
+        expect(getStyles()).toMatchSnapshot();
+    });
 });

--- a/packages/styled/spec/index.test.js
+++ b/packages/styled/spec/index.test.js
@@ -182,8 +182,22 @@ describe('styled', () => {
             padding: 10px;
         `;
 
+        const after = css`
+            &::after {
+                content: '';
+            }
+        `;
+
+        const before = css`
+            ::before {
+                content: '';
+            }
+        `;
+
         const Button = styled.button`
             ${padding}
+            ${after}
+            ${before}
             color: ${props => props.color};
         `;
 

--- a/packages/styled/spec/index.test.js
+++ b/packages/styled/spec/index.test.js
@@ -235,11 +235,22 @@ describe('styled', () => {
         expect(getStyles()).toMatchSnapshot();
     });
 
-    it('should work with mixins as strings', () => {
+    it('should work with string mixins', () => {
         const padding = `
             padding: 10px;
         `;
 
+        const Button = styled.button`
+            ${padding}
+        `;
+
+        const wrapper = render(<Button width={100}>click me</Button>);
+
+        expect(wrapper).toMatchSnapshot();
+        expect(getStyles()).toMatchSnapshot();
+    });
+
+    it('should work with dynamic mixins', () => {
         const dynamicMixin = ({width}) =>
             css`
                 transform: translateX(${({width}) => `-${2 * width}`}px);
@@ -247,13 +258,16 @@ describe('styled', () => {
             `;
 
         const Button = styled.button`
-            ${padding}
             ${dynamicMixin}
         `;
 
-        const wrapper = render(<Button width={100}>click me</Button>);
+        const wrapper = shallow(<Button width={0}>click me</Button>);
 
-        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.render()).toMatchSnapshot();
+        expect(getStyles()).toMatchSnapshot();
+
+        wrapper.setProps({width: 100});
+        expect(wrapper.render()).toMatchSnapshot();
         expect(getStyles()).toMatchSnapshot();
     });
 

--- a/packages/styled/spec/index.test.js
+++ b/packages/styled/spec/index.test.js
@@ -52,6 +52,34 @@ describe('styled', () => {
         expect(getStyles()).toMatchSnapshot();
     });
 
+    it('should process only namespaced attributes', () => {
+        const Button = styled.button`
+            color: red;
+
+            &[use|size='m'] {
+                font-size: 14px;
+            }
+
+            &[|size='s'] {
+                font-size: 14px;
+            }
+
+            &[disabled] {
+                opacity: 0.5;
+            }
+        `;
+
+        Button.defaultProps = {size: 'm'};
+
+        const wrapper = shallow(<Button>click me</Button>);
+        expect(wrapper.render()).toMatchSnapshot();
+        expect(getStyles()).toMatchSnapshot();
+
+        wrapper.setProps({size: 's'});
+        expect(wrapper.render()).toMatchSnapshot();
+        expect(getStyles()).toMatchSnapshot();
+    });
+
     it('should apply styles for Component', () => {
         const Button = styled(props => <button {...props} />)`
             color: red;

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/svelte
+
+
+
+
+
 ## [0.0.1-alpha.61](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.60...v0.0.1-alpha.61) (2019-06-03)
 
 

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.63](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.62...v0.0.1-alpha.63) (2019-06-04)
+
+
+### Bug Fixes
+
+* **svelte:** fix svelte preprocess ([5e60204](https://github.com/lttb/reshadow/commit/5e60204))
+
+
+
+
+
 ## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/svelte

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.61](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.60...v0.0.1-alpha.61) (2019-06-03)
+
+
+### Bug Fixes
+
+* **svelte:** use @reshadow/core for the runtime ([703668d](https://github.com/lttb/reshadow/commit/703668d))
+
+
+
+
+
 ## [0.0.1-alpha.59](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.58...v0.0.1-alpha.59) (2019-06-03)
 
 

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.58](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.57...v0.0.1-alpha.58) (2019-06-03)
+
+
+### Bug Fixes
+
+* **svelte:** fix modifiers ([38d2c83](https://github.com/lttb/reshadow/commit/38d2c83))
+
+
+
+
+
 ## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/svelte

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/svelte
+
+
+
+
+
 ## [0.0.1-alpha.51](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.50...v0.0.1-alpha.51) (2019-05-31)
 
 **Note:** Version bump only for package @reshadow/svelte

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.59](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.58...v0.0.1-alpha.59) (2019-06-03)
+
+
+### Bug Fixes
+
+* **svelte:** fix variables interpolation ([1ff22b3](https://github.com/lttb/reshadow/commit/1ff22b3))
+
+
+
+
+
 ## [0.0.1-alpha.58](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.57...v0.0.1-alpha.58) (2019-06-03)
 
 

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -26,9 +26,7 @@
         "@babel/types": "^7.4.4",
         "@reshadow/babel": "^0.0.1-alpha.62",
         "@reshadow/core": "^0.0.1-alpha.62",
+        "common-tags": "1.8.0",
         "svelte": "^3.0.0"
-    },
-    "devDependencies": {
-        "common-tags": "1.8.0"
     }
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/svelte",
-    "version": "0.0.1-alpha.62",
+    "version": "0.0.1-alpha.63",
     "description": "reshadow svelte",
     "main": "index.js",
     "repository": {
@@ -24,8 +24,8 @@
         "@babel/parser": "^7.4.4",
         "@babel/traverse": "^7.4.4",
         "@babel/types": "^7.4.4",
-        "@reshadow/babel": "^0.0.1-alpha.62",
-        "@reshadow/core": "^0.0.1-alpha.62",
+        "@reshadow/babel": "^0.0.1-alpha.63",
+        "@reshadow/core": "^0.0.1-alpha.63",
         "common-tags": "1.8.0",
         "svelte": "^3.0.0"
     }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/svelte",
-    "version": "0.0.1-alpha.51",
+    "version": "0.0.1-alpha.57",
     "description": "reshadow svelte",
     "main": "index.js",
     "repository": {
@@ -24,8 +24,8 @@
         "@babel/parser": "^7.4.4",
         "@babel/traverse": "^7.4.4",
         "@babel/types": "^7.4.4",
-        "@reshadow/babel": "^0.0.1-alpha.51",
-        "@reshadow/core": "^0.0.1-alpha.49",
+        "@reshadow/babel": "^0.0.1-alpha.57",
+        "@reshadow/core": "^0.0.1-alpha.57",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/svelte",
-    "version": "0.0.1-alpha.57",
+    "version": "0.0.1-alpha.58",
     "description": "reshadow svelte",
     "main": "index.js",
     "repository": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/svelte",
-    "version": "0.0.1-alpha.59",
+    "version": "0.0.1-alpha.61",
     "description": "reshadow svelte",
     "main": "index.js",
     "repository": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/svelte",
-    "version": "0.0.1-alpha.61",
+    "version": "0.0.1-alpha.62",
     "description": "reshadow svelte",
     "main": "index.js",
     "repository": {
@@ -24,8 +24,8 @@
         "@babel/parser": "^7.4.4",
         "@babel/traverse": "^7.4.4",
         "@babel/types": "^7.4.4",
-        "@reshadow/babel": "^0.0.1-alpha.57",
-        "@reshadow/core": "^0.0.1-alpha.57",
+        "@reshadow/babel": "^0.0.1-alpha.62",
+        "@reshadow/core": "^0.0.1-alpha.62",
         "svelte": "^3.0.0"
     },
     "devDependencies": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/svelte",
-    "version": "0.0.1-alpha.58",
+    "version": "0.0.1-alpha.59",
     "description": "reshadow svelte",
     "main": "index.js",
     "repository": {

--- a/packages/svelte/preprocess.js
+++ b/packages/svelte/preprocess.js
@@ -55,7 +55,7 @@ const preprocess = options => ({
          */
         if (!reshadowImport) {
             if (style.attributes.includes('reshadow')) {
-                script.content += `import __styled__ from "reshadow";__styled__\`${style.content.replace(
+                script.content += `import __styled__ from "@reshadow/core";__styled__\`${style.content.replace(
                     /val\((\w+)\)/gms,
                     // eslint-disable-next-line
                     '${$1}',

--- a/packages/svelte/spec/__snapshots__/index.test.js.snap
+++ b/packages/svelte/spec/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`svelte preprocess should transform the code 1`] = `
 Object {
   "code": "<script>import styled, { __extract__, set, create, css, use, map, __css__ } from \\"@reshadow/core\\";
+export let name = 'name';
 export let disabled = false;
 export let size = 'm';
 export let variant = 'action';
@@ -22,7 +23,7 @@ $: __styles__ = styled((set([styled_c8], \`--c8_0:\${color};\`), __extract__()))
 
   <svelte:body class={styled.styles[\\"__svelte:body\\"]} style={__styles__.$$style} on:click={() => console.log('body click')} />
 
-  <h1 class={styled.styles[\\"__h1\\"]} style={__styles__.$$style}>hello world</h1>
+  <h1 class={styled.styles[\\"__h1\\"]} style={__styles__.$$style}>hello {name}</h1>
 
   <button {...map(\\"button\\", {
     disabled: disabled,

--- a/packages/svelte/spec/__snapshots__/index.test.js.snap
+++ b/packages/svelte/spec/__snapshots__/index.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "code": "<script>import styled, { __extract__, set, create, css, use, map, __css__ } from \\"@reshadow/core\\";
 export let disabled = false;
 export let size = 'm';
+export let variant = 'action';
 const styled_c8 = create([(__css__(\`.___h1_rzsno_1 {
     color: var(--c8_0);
 }\`
@@ -24,11 +25,12 @@ $: __styles__ = styled((set([styled_c8], \`--c8_0:\${color};\`), __extract__()))
   <h1 class={styled.styles[\\"__h1\\"]} style={__styles__.$$style}>hello world</h1>
 
   <button {...map(\\"button\\", {
-    disabled: true,
+    disabled: disabled,
     $$style: __styles__.$$style
   }, use({
-    variant: \\"action\\",
-    size: true
+    state: \\"pending\\",
+    variant: variant,
+    size: size
   }))}>click me</button>",
 }
 `;

--- a/packages/svelte/spec/__snapshots__/index.test.js.snap
+++ b/packages/svelte/spec/__snapshots__/index.test.js.snap
@@ -2,7 +2,8 @@
 
 exports[`svelte preprocess should transform the code 1`] = `
 Object {
-  "code": "<script>import styled, { __extract__, set, create, css, use, map, __css__ } from \\"@reshadow/core\\";
+  "code": "<script>import {__init__ as __reshadow__} from '@reshadow/svelte';
+import {beforeUpdate as __bu__, afterUpdate as __au__} from 'svelte';import styled, { __extract__, set, create, css, use, map, __css__ } from \\"@reshadow/core\\";
 export let name = 'name';
 export let disabled = false;
 export let size = 'm';
@@ -15,11 +16,11 @@ const styled_c8 = create([(__css__(\`.___h1_rzsno_1 {
   \\"__h1\\": \`___h1_rzsno_1\`
 })]);
 $: __styles__ = styled((set([styled_c8], \`--c8_0:\${color};\`), __extract__()));
-;require('@reshadow/svelte').__init__(require('svelte'), () => __styles__, () => {
-                styled = styled;
-                map = map;
-            });
-            </script><style></style>
+;const __getStyles__ = () => __styles__;
+__reshadow__({beforeUpdate: __bu__, afterUpdate: __au__}, __getStyles__, () => {
+    styled = styled;
+    map = map;
+});</script>
 
   <svelte:body class={styled.styles[\\"__svelte:body\\"]} style={__styles__.$$style} on:click={() => console.log('body click')} />
 

--- a/packages/svelte/spec/index.test.js
+++ b/packages/svelte/spec/index.test.js
@@ -18,6 +18,7 @@ describe('svelte preprocess', () => {
 
                 export let disabled = false
                 export let size = 'm'
+                export let variant = 'action'
 
                 styled\`
                     h1 {
@@ -30,7 +31,7 @@ describe('svelte preprocess', () => {
 
             <h1>hello world</h1>
 
-            <button :variant="action" :{size} {disabled}>click me</button>
+            <button :state="pending" :variant={variant} :{size} {disabled}>click me</button>
         `;
 
         expect(code).toMatchSnapshot();

--- a/packages/svelte/spec/index.test.js
+++ b/packages/svelte/spec/index.test.js
@@ -16,6 +16,7 @@ describe('svelte preprocess', () => {
             <script>
                 import styled from 'reshadow'
 
+                export let name = 'name'
                 export let disabled = false
                 export let size = 'm'
                 export let variant = 'action'
@@ -29,7 +30,7 @@ describe('svelte preprocess', () => {
 
             <svelte:body on:click={() => console.log('body click')} />
 
-            <h1>hello world</h1>
+            <h1>hello {name}</h1>
 
             <button :state="pending" :variant={variant} :{size} {disabled}>click me</button>
         `;

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.63](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.62...v0.0.1-alpha.63) (2019-06-04)
+
+**Note:** Version bump only for package @reshadow/vue
+
+
+
+
+
 ## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/vue

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/vue
+
+
+
+
+
 ## [0.0.1-alpha.49](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.48...v0.0.1-alpha.49) (2019-05-31)
 
 **Note:** Version bump only for package @reshadow/vue

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.62](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.61...v0.0.1-alpha.62) (2019-06-03)
+
+**Note:** Version bump only for package @reshadow/vue
+
+
+
+
+
 ## [0.0.1-alpha.57](https://github.com/lttb/reshadow/compare/v0.0.1-alpha.56...v0.0.1-alpha.57) (2019-06-03)
 
 **Note:** Version bump only for package @reshadow/vue

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/vue",
-    "version": "0.0.1-alpha.57",
+    "version": "0.0.1-alpha.62",
     "description": "reshadow vue",
     "main": "index.js",
     "repository": {
@@ -20,6 +20,6 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/core": "^0.0.1-alpha.57"
+        "@reshadow/core": "^0.0.1-alpha.62"
     }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/vue",
-    "version": "0.0.1-alpha.49",
+    "version": "0.0.1-alpha.57",
     "description": "reshadow vue",
     "main": "index.js",
     "repository": {
@@ -20,6 +20,6 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/core": "^0.0.1-alpha.49"
+        "@reshadow/core": "^0.0.1-alpha.57"
     }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshadow/vue",
-    "version": "0.0.1-alpha.62",
+    "version": "0.0.1-alpha.63",
     "description": "reshadow vue",
     "main": "index.js",
     "repository": {
@@ -20,6 +20,6 @@
         "build": "../../build.sh"
     },
     "dependencies": {
-        "@reshadow/core": "^0.0.1-alpha.62"
+        "@reshadow/core": "^0.0.1-alpha.63"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,6 +878,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@emotion/stylis@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.3.tgz#3ca7e9bcb31b3cb4afbaeb66156d86ee85e23246"
+  integrity sha512-M3nMfJ6ndJMYloSIbYEBq6G3eqoYD41BpDOxreE8j0cb4fzz/5qvmqU9Mb2hzsXcCnIlGlWhS03PCzVGvTAe0Q==
+
 "@emotion/unitless@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
@@ -10507,7 +10512,7 @@ reshadow@0.0.1-alpha.26:
     "@reshadow/webpack" "^0.0.1-alpha.21"
 
 "reshadow@file:packages/core":
-  version "0.0.1-alpha.42"
+  version "0.0.1-alpha.49"
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -11440,7 +11445,7 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
-stylis@^3.5.4:
+stylis@3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==


### PR DESCRIPTION
Should fix an issue from https://github.com/lttb/reshadow/issues/20#issuecomment-498030847

The problem is that `reshadow` worked only with mixins like:
```js
const mixin = css`
  &::after { ... }
`
```

But `styled-components` also allows this syntax:
```js
const mixin = css`
  ::after { ... }
`
```

Reshadow parser should support this behaviour for the backward compatibility, but the first example should be considered as preferred.