### PR TITLE
Babel plugin - variables inside css comments

### DIFF
--- a/packages/babel/spec/__snapshots__/index.test.js.snap
+++ b/packages/babel/spec/__snapshots__/index.test.js.snap
@@ -69,7 +69,6 @@ const App = ({
   disabled,
   type
 }) => styled((set([styled_c8, styles], {
-  \\"--c8_0\\": type,
   \\"--c8_1\\": disabled
 }), React.createElement(\\"button\\", map(\\"button\\", {
   type: type,
@@ -103,9 +102,7 @@ const App = ({
   disabled,
   type
 }) => styled((set([styled_c8, styles], {
-  \\"--c8_0\\": type,
   \\"--c8_1\\": disabled,
-  \\"--c8_2\\": getHeight(type),
   \\"--c8_3\\": color
 }), React.createElement(\\"button\\", map(\\"button\\", {
   type: type,

--- a/packages/babel/spec/__snapshots__/index.test.js.snap
+++ b/packages/babel/spec/__snapshots__/index.test.js.snap
@@ -115,6 +115,41 @@ const App = ({
 export default App;"
 `;
 
+exports[`babel macro should NOT process a variable inside a comment, multiple comments in a single quasi 1`] = `
+"import React from 'react';
+import styled, { set, create, css, use, map, __css__ } from \\"@reshadow/core\\";
+import getHeight from './utils';
+const styled_c8 = create([(__css__(\`/* extremely insightful comment w/ \${type} */
+.___button_1sfi5_1 {
+    /* yet another comment */
+    color: red;
+    height: var(--c8_1);
+    /* height: \${someVar}; */
+    /* more comments */
+    background: var(--c8_3);
+}\`
+/*__css_end__*/
+, \\"3895876906\\"), {
+  \\"__button\\": \`___button_1sfi5_1\`
+})]);
+
+const App = ({
+  disabled,
+  type
+}) => styled((set([styled_c8, styles], {
+  \\"--c8_1\\": disabled,
+  \\"--c8_3\\": color
+}), React.createElement(\\"button\\", map(\\"button\\", {
+  type: type,
+  disabled: disabled,
+  $$style: styled.$$style
+}, use({
+  theme: \\"normal\\"
+})), \\"content\\")));
+
+export default App;"
+`;
+
 exports[`babel macro should keep named imports 1`] = `
 "import React from 'react';
 import styled, { use, set, create, css, map, __css__ } from \\"@reshadow/core\\";

--- a/packages/babel/spec/__snapshots__/index.test.js.snap
+++ b/packages/babel/spec/__snapshots__/index.test.js.snap
@@ -52,6 +52,72 @@ new Vue({
 });"
 `;
 
+exports[`babel macro should NOT process a variable inside a comment 1`] = `
+"import React from 'react';
+import styled, { set, create, css, use, map, __css__ } from \\"@reshadow/core\\";
+const styled_c8 = create([(__css__(\`/* extremely insightful comment w/ \${type} */
+.___button_1pj20_1 {
+    color: red;
+    height: var(--c8_1);
+}\`
+/*__css_end__*/
+, \\"3720444030\\"), {
+  \\"__button\\": \`___button_1pj20_1\`
+})]);
+
+const App = ({
+  disabled,
+  type
+}) => styled((set([styled_c8, styles], {
+  \\"--c8_0\\": type,
+  \\"--c8_1\\": disabled
+}), React.createElement(\\"button\\", map(\\"button\\", {
+  type: type,
+  disabled: disabled,
+  $$style: styled.$$style
+}, use({
+  theme: \\"normal\\"
+})), \\"content\\")));
+
+export default App;"
+`;
+
+exports[`babel macro should NOT process a variable inside a comment, multiple comments 1`] = `
+"import React from 'react';
+import styled, { set, create, css, use, map, __css__ } from \\"@reshadow/core\\";
+import getHeight from './utils';
+const styled_c8 = create([(__css__(\`/* extremely insightful comment w/ \${type} */
+.___button_eg4jy_1 {
+    /* yet another comment */
+    color: red;
+    height: var(--c8_1);
+    /* height: \${someVar}; */
+    background: var(--c8_3);
+}\`
+/*__css_end__*/
+, \\"873612821\\"), {
+  \\"__button\\": \`___button_eg4jy_1\`
+})]);
+
+const App = ({
+  disabled,
+  type
+}) => styled((set([styled_c8, styles], {
+  \\"--c8_0\\": type,
+  \\"--c8_1\\": disabled,
+  \\"--c8_2\\": getHeight(type),
+  \\"--c8_3\\": color
+}), React.createElement(\\"button\\", map(\\"button\\", {
+  type: type,
+  disabled: disabled,
+  $$style: styled.$$style
+}, use({
+  theme: \\"normal\\"
+})), \\"content\\")));
+
+export default App;"
+`;
+
 exports[`babel macro should keep named imports 1`] = `
 "import React from 'react';
 import styled, { use, set, create, css, map, __css__ } from \\"@reshadow/core\\";
@@ -107,6 +173,31 @@ const styled_c8 = create([(__css__(\`.___button_d2nb2_1 {
 /*__css_end__*/
 , \\"790506970\\"), {
   \\"__button\\": \`___button_d2nb2_1\`
+})]);
+
+const App = ({
+  disabled,
+  type
+}) => styled((set([styled_c8, styles]), React.createElement(\\"button\\", map(\\"button\\", {
+  type: type,
+  disabled: disabled
+}, use({
+  theme: \\"normal\\"
+})), \\"content\\")));
+
+export default App;"
+`;
+
+exports[`babel macro should process styles with comments 1`] = `
+"import React from 'react';
+import styled, { set, create, css, use, map, __css__ } from \\"@reshadow/core\\";
+const styled_c8 = create([(__css__(\`/* extremely insightful comment */
+.___button_xwari_1 {
+    color: red;
+}\`
+/*__css_end__*/
+, \\"2049633721\\"), {
+  \\"__button\\": \`___button_xwari_1\`
 })]);
 
 const App = ({

--- a/packages/babel/spec/index.test.js
+++ b/packages/babel/spec/index.test.js
@@ -499,6 +499,78 @@ describe('babel', () => {
             expect(code).toMatchSnapshot();
         });
 
+        it('should process styles with comments', async () => {
+            const {code} = await transform.with(options)`
+                import React from 'react'
+                import styled from '../../macro'
+
+                const App = ({disabled, type}) => styled(styles)\`
+                    /* extremely insightful comment */
+                    button {
+                        color: red;
+                    }
+                \`(
+                    <button type={type} disabled={disabled} use:theme="normal">
+                        content
+                    </button>
+                )
+
+                export default App
+            `;
+
+            expect(code).toMatchSnapshot();
+        });
+
+        it('should NOT process a variable inside a comment', async () => {
+            const {code} = await transform.with(options)`
+                import React from 'react'
+                import styled from '../../macro'
+
+                const App = ({disabled, type}) => styled(styles)\`
+                    /* extremely insightful comment w/ \${type} */
+                    button {
+                        color: red;
+                        height: \${disabled};
+                    }
+                \`(
+                    <button type={type} disabled={disabled} use:theme="normal">
+                        content
+                    </button>
+                )
+
+                export default App
+            `;
+
+            expect(code).toMatchSnapshot();
+        });
+
+        it('should NOT process a variable inside a comment, multiple comments', async () => {
+            const {code} = await transform.with(options)`
+                import React from 'react'
+                import styled from '../../macro'
+                import getHeight from './utils'
+
+                const App = ({disabled, type}) => styled(styles)\`
+                    /* extremely insightful comment w/ \${type} */
+                    button {
+                        /* yet another comment */
+                        color: red;
+                        height: \${disabled};
+                        /* height: \${getHeight(type)}; */
+                        background: \${color};
+                    }
+                \`(
+                    <button type={type} disabled={disabled} use:theme="normal">
+                        content
+                    </button>
+                )
+
+                export default App
+            `;
+
+            expect(code).toMatchSnapshot();
+        });
+
         it('should keep named imports', async () => {
             const {code} = await transform.with(options)`
                 import React from 'react'

--- a/packages/babel/spec/index.test.js
+++ b/packages/babel/spec/index.test.js
@@ -571,6 +571,34 @@ describe('babel', () => {
             expect(code).toMatchSnapshot();
         });
 
+        it('should NOT process a variable inside a comment, multiple comments in a single quasi', async () => {
+            const {code} = await transform.with(options)`
+                import React from 'react'
+                import styled from '../../macro'
+                import getHeight from './utils'
+
+                const App = ({disabled, type}) => styled(styles)\`
+                    /* extremely insightful comment w/ \${type} */
+                    button {
+                        /* yet another comment */
+                        color: red;
+                        height: \${disabled};
+                        /* height: \${getHeight(type)}; */
+                        /* more comments */
+                        background: \${color};
+                    }
+                \`(
+                    <button type={type} disabled={disabled} use:theme="normal">
+                        content
+                    </button>
+                )
+
+                export default App
+            `;
+
+            expect(code).toMatchSnapshot();
+        });
+
         it('should keep named imports', async () => {
             const {code} = await transform.with(options)`
                 import React from 'react'


### PR DESCRIPTION
This PR directly targets #48 

Now babel should not transpile expressions within css comment blocks.

I've tried to keep the comments as is but no luck. It seems babel does not provide a way to get a raw string of the expression in a template string placeholder which made me use the identifier name where possible or fallback to a `someVar` which is not ideal but is better than a runtime error. I am yet to look at the postcss side of things but look forward to it.