### PR TITLE
Fix: Append styles before DOM is ready

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -111,6 +111,8 @@ const clearStyles = () => {
 
 const RESHADOW_ID = '__reshadow__';
 
+const appendChildToDocumentHead = element => document.head.appendChild(element);
+
 const css = (code, hash) => {
     const id = `reshadow-${hash}`;
 
@@ -123,8 +125,16 @@ const css = (code, hash) => {
     if (!container) {
         container = document.createElement('object');
         container.id = RESHADOW_ID;
-        document.head.appendChild(container);
+
+        if (document.head) {
+            appendChildToDocumentHead(container);
+        } else {
+            document.addEventListener('DOMContentLoaded', () => {
+                appendChildToDocumentHead(container);
+            });
+        }
     }
+
     let css = document.getElementById(id);
     if (!css) {
         css = document.createElement('style');


### PR DESCRIPTION
Fix created because `@reshadow/core` tries append styles on `HTMLHeadElement` before DOM is ready.

---

> Why are you created an `appendChildToDocumentHead` function?

I think it will be better, because uglifiers can minimize this code better. But location of this function can be changed.

> Why `DOMContentLoaded`?

This is nearest event of DOM is ready. We can use some of hacks with DOM like insert script with block of code when reshadow has access to `document.documentElement` and then remove it.