### PR TITLE
feat(utils): support svg tag names

### DIFF
--- a/packages/utils/html-tags/index.js
+++ b/packages/utils/html-tags/index.js
@@ -1,1 +1,0 @@
-module.exports = new Set(require('html-tags'));

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -2,7 +2,7 @@ const path = require('path');
 const resolve = require('resolve');
 const stringHash = require('string-hash');
 
-const tags = require('./html-tags');
+const tags = require('./tags');
 
 const componentRe = /^[A-Z][a-zA-Z]*/;
 const isCustomElement = name =>

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,6 +22,7 @@
     "dependencies": {
         "html-tags": "^3.0.0",
         "resolve": "^1.11.1",
-        "string-hash": "^1.1.3"
+        "string-hash": "^1.1.3",
+        "svg-tag-names": "^2.0.1"
     }
 }

--- a/packages/utils/tags/index.js
+++ b/packages/utils/tags/index.js
@@ -1,0 +1,6 @@
+const html = require('html-tags');
+const svg = require('svg-tag-names');
+
+module.exports = new Set([...html, ...svg]);
+module.exports.html = new Set(html);
+module.exports.svg = new Set(svg);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10455,6 +10455,11 @@ svelte@^3.6.7:
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.6.7.tgz#20e814b79aac4009d4bc1ecf0c9287a6bf7e96fb"
   integrity sha512-9HzhPxWNLi+ZBhxL3HJ8jwwu+u+XfHtVF3uEJ2m8/JOdnaTC9D2qiEwOncgI7z/pN+VumgKQtZoHtvYCW6fHqg==
 
+svg-tag-names@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/svg-tag-names/-/svg-tag-names-2.0.1.tgz#acf5655faaa2e4b173007599226b906be1b38a29"
+  integrity sha512-BEZ508oR+X/b5sh7bT0RqDJ7GhTpezjj3P1D4kugrOaPs6HijviWksoQ63PS81vZn0QCjZmVKjHDBniTo+Domg==
+
 svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"


### PR DESCRIPTION
Adds support for svg tag names. There is a failing eslint test in the eslint package. I believe it will fix itself after bumping the version of utils package