### PR TITLE
fix(react): support React.Fragment

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -7,9 +7,27 @@ export function getDisplayName(Base) {
     return Base.displayName || Base.name || 'Component';
 }
 
+function isBuiltInType(type) {
+    switch (type) {
+        case React.Fragment:
+        case React.Profiler:
+        case React.StrictMode:
+        case React.Suspense: {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 export function jsx() {
     const args = Array.prototype.slice.call(arguments);
     let element = args[0];
+
+    if (isBuiltInType(element)) {
+        return React.createElement.apply(null, args);
+    }
+
     if (typeof element === 'string' && !tags.has(element)) {
         args[0] = 'div';
     } else if (typeof element === 'function') {
@@ -24,6 +42,15 @@ export {css, use, create, keyframes};
 const reactStyled = createStyled(elem => {
     const style = styled[KEYS.__style__];
     let result = styled(elem);
+
+    /**
+     * At the moment, we just skip styles inlining with root Fragments
+     * TODO(lttb): support dynamic and inline styles for Components with Fragments root node
+     */
+    if (isBuiltInType(result.type)) {
+        return result;
+    }
+
     if (style && result) {
         result = React.cloneElement(result, {
             style: Object.assign({}, style, result.props.style),

--- a/packages/react/spec/__snapshots__/index.test.js.snap
+++ b/packages/react/spec/__snapshots__/index.test.js.snap
@@ -158,3 +158,13 @@ exports[`react should apply styles 1`] = `
 `;
 
 exports[`react should apply styles 2`] = `".__button_olz31h{color:red;}"`;
+
+exports[`react should work with Fragments 1`] = `
+<button
+  class="__button_2wxhvw"
+>
+  click me
+</button>
+`;
+
+exports[`react should work with Fragments 2`] = `".__button_2wxhvw{margin:10px;}"`;

--- a/packages/react/spec/index.test.js
+++ b/packages/react/spec/index.test.js
@@ -234,4 +234,20 @@ describe('react', () => {
         expect(wrapper.render()).toMatchSnapshot();
         expect(getStyles()).toMatchSnapshot();
     });
+
+    it('should work with Fragments', () => {
+        const Button = ({children}) => styled`
+            button {
+                margin: 10px;
+            }
+        `(
+            <>
+                <button>{children}</button>
+            </>,
+        );
+
+        const wrapper = shallow(<Button>click me</Button>);
+        expect(wrapper.render()).toMatchSnapshot();
+        expect(getStyles()).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
Support `React.Fragment` for `@reshadow/react` runtime package

For example,

```jsx
return styled`
  button { color: red }
`(
  <>
    <button>click</button>
  </>
)
```